### PR TITLE
Nullable Reference Types support and refactor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,11 @@
-﻿<Project>
-  <!-- Leave this file here, even if it's empty. It stops chaining imports. -->
+<Project>
+  <!-- There is nothing else to import. -->
 
   <PropertyGroup>
     <!-- Ensure changes to this file cause project rebuilds. -->
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/Tingle.Extensions.AnyOf/AnyOf.cs
+++ b/src/Tingle.Extensions.AnyOf/AnyOf.cs
@@ -36,7 +36,7 @@
         /// Initializes a new instance of the <see cref="AnyOf{T1, T2}"/> class with type <c>T1</c>.
         /// </summary>
         /// <param name="value">The value to hold.</param>
-        public AnyOf(T1 value)
+        public AnyOf(T1? value)
         {
             value1 = value;
             setValue = Values.Value1;
@@ -46,7 +46,7 @@
         /// Initializes a new instance of the <see cref="AnyOf{T1, T2}"/> class with type <c>T2</c>.
         /// </summary>
         /// <param name="value">The value to hold.</param>
-        public AnyOf(T2 value)
+        public AnyOf(T2? value)
         {
             value2 = value;
             setValue = Values.Value2;
@@ -133,7 +133,7 @@
         /// <c>T1</c>.
         /// </summary>
         /// <param name="value">The value to hold.</param>
-        public AnyOf(T1 value)
+        public AnyOf(T1? value)
         {
             value1 = value;
             setValue = Values.Value1;
@@ -144,7 +144,7 @@
         /// <c>T2</c>.
         /// </summary>
         /// <param name="value">The value to hold.</param>
-        public AnyOf(T2 value)
+        public AnyOf(T2? value)
         {
             value2 = value;
             setValue = Values.Value2;
@@ -155,7 +155,7 @@
         /// <c>T3</c>.
         /// </summary>
         /// <param name="value">The value to hold.</param>
-        public AnyOf(T3 value)
+        public AnyOf(T3? value)
         {
             value3 = value;
             setValue = Values.Value3;

--- a/src/Tingle.Extensions.AnyOf/AnyOf.cs
+++ b/src/Tingle.Extensions.AnyOf/AnyOf.cs
@@ -7,11 +7,11 @@
     {
         /// <summary>Gets the value of the current <see cref="AnyOf"/> object.</summary>
         /// <returns>The value of the current <see cref="AnyOf"/> object.</returns>
-        public abstract object Value { get; }
+        public abstract object? Value { get; }
 
         /// <summary>Gets the type of the current <see cref="AnyOf"/> object.</summary>
         /// <returns>The type of the current <see cref="AnyOf"/> object.</returns>
-        public abstract Type Type { get; }
+        public abstract Type? Type { get; }
 
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>
@@ -28,8 +28,8 @@
     /// <typeparam name="T2">The second possible type of the value.</typeparam>
     public class AnyOf<T1, T2> : AnyOf
     {
-        private readonly T1 value1;
-        private readonly T2 value2;
+        private readonly T1? value1;
+        private readonly T2? value2;
         private readonly Values setValue;
 
         /// <summary>
@@ -60,7 +60,7 @@
 
         /// <summary>Gets the value of the current <see cref="AnyOf{T1, T2}"/> object.</summary>
         /// <returns>The value of the current <see cref="AnyOf{T1, T2}"/> object.</returns>
-        public override object Value => setValue switch
+        public override object? Value => setValue switch
         {
             Values.Value1 => value1,
             Values.Value2 => value2,
@@ -69,7 +69,7 @@
 
         /// <summary>Gets the type of the current <see cref="AnyOf{T1, T2}"/> object.</summary>
         /// <returns>The type of the current <see cref="AnyOf{T1, T2}"/> object.</returns>
-        public override Type Type => setValue switch
+        public override Type? Type => setValue switch
         {
             Values.Value1 => typeof(T1),
             Values.Value2 => typeof(T2),
@@ -81,14 +81,14 @@
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2>(T1 value) => value == null ? null : new AnyOf<T1, T2>(value);
+        public static implicit operator AnyOf<T1, T2>?(T1? value) => value == null ? null : new AnyOf<T1, T2>(value);
 
         /// <summary>
         /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2}"/> object.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2>(T2 value) => value == null ? null : new AnyOf<T1, T2>(value);
+        public static implicit operator AnyOf<T1, T2>?(T2? value) => value == null ? null : new AnyOf<T1, T2>(value);
 
         /// <summary>
         /// Converts an <see cref="AnyOf{T1, T2}"/> object to a value of type <c>T1</c>.
@@ -98,7 +98,7 @@
         /// A value of type <c>T1</c>. If the <see cref="AnyOf{T1, T2}"/> object currently
         /// holds a value of a different type, the default value for type <c>T1</c> is returned.
         /// </returns>
-        public static implicit operator T1(AnyOf<T1, T2> anyOf) => anyOf.value1;
+        public static implicit operator T1?(AnyOf<T1, T2> anyOf) => anyOf.value1;
 
         /// <summary>
         /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2}"/> object.
@@ -108,7 +108,7 @@
         /// A value of type <c>T2</c>. If the <see cref="AnyOf{T1, T2}"/> object currently
         /// holds a value of a different type, the default value for type <c>T2</c> is returned.
         /// </returns>
-        public static implicit operator T2(AnyOf<T1, T2> anyOf) => anyOf.value2;
+        public static implicit operator T2?(AnyOf<T1, T2> anyOf) => anyOf.value2;
     }
 
     /// <summary>
@@ -123,9 +123,9 @@
     /// <typeparam name="T3">The third possible type of the value.</typeparam>
     public class AnyOf<T1, T2, T3> : AnyOf
     {
-        private readonly T1 value1;
-        private readonly T2 value2;
-        private readonly T3 value3;
+        private readonly T1? value1;
+        private readonly T2? value2;
+        private readonly T3? value3;
         private readonly Values setValue;
 
         /// <summary>
@@ -170,7 +170,7 @@
 
         /// <summary>Gets the value of the current <see cref="AnyOf{T1, T2, T3}"/> object.</summary>
         /// <returns>The value of the current <see cref="AnyOf{T1, T2, T3}"/> object.</returns>
-        public override object Value => setValue switch
+        public override object? Value => setValue switch
         {
             Values.Value1 => value1,
             Values.Value2 => value2,
@@ -180,7 +180,7 @@
 
         /// <summary>Gets the type of the current <see cref="AnyOf{T1, T2, T3}"/> object.</summary>
         /// <returns>The type of the current <see cref="AnyOf{T1, T2, T3}"/> object.</returns>
-        public override Type Type => setValue switch
+        public override Type? Type => setValue switch
         {
             Values.Value1 => typeof(T1),
             Values.Value2 => typeof(T2),
@@ -193,21 +193,21 @@
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2, T3>(T1 value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
+        public static implicit operator AnyOf<T1, T2, T3>?(T1? value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
 
         /// <summary>
         /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2, T3}"/> object.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2, T3>(T2 value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
+        public static implicit operator AnyOf<T1, T2, T3>?(T2? value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
 
         /// <summary>
         /// Converts a value of type <c>T3</c> to an <see cref="AnyOf{T1, T2, T3}"/> object.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2, T3>(T3 value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
+        public static implicit operator AnyOf<T1, T2, T3>?(T3? value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
 
         /// <summary>
         /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T1</c>.
@@ -217,7 +217,7 @@
         /// A value of type <c>T1</c>. If the <see cref="AnyOf{T1, T2, T3}"/> object currently
         /// holds a value of a different type, the default value for type <c>T3</c> is returned.
         /// </returns>
-        public static implicit operator T1(AnyOf<T1, T2, T3> anyOf) => anyOf.value1;
+        public static implicit operator T1?(AnyOf<T1, T2, T3> anyOf) => anyOf.value1;
 
         /// <summary>
         /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T2</c>.
@@ -227,7 +227,7 @@
         /// A value of type <c>T2</c>. If the <see cref="AnyOf{T1, T2, T3}"/> object currently
         /// holds a value of a different type, the default value for type <c>T3</c> is returned.
         /// </returns>
-        public static implicit operator T2(AnyOf<T1, T2, T3> anyOf) => anyOf.value2;
+        public static implicit operator T2?(AnyOf<T1, T2, T3> anyOf) => anyOf.value2;
 
         /// <summary>
         /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T3</c>.
@@ -237,6 +237,6 @@
         /// A value of type <c>T3</c>. If the <see cref="AnyOf{T1, T2, T3}"/> object currently
         /// holds a value of a different type, the default value for type <c>T3</c> is returned.
         /// </returns>
-        public static implicit operator T3(AnyOf<T1, T2, T3> anyOf) => anyOf.value3;
+        public static implicit operator T3?(AnyOf<T1, T2, T3> anyOf) => anyOf.value3;
     }
 }

--- a/src/Tingle.Extensions.AnyOf/IAnyOf.cs
+++ b/src/Tingle.Extensions.AnyOf/IAnyOf.cs
@@ -7,10 +7,10 @@
     {
         /// <summary>Gets the value of the current <see cref="IAnyOf"/> object.</summary>
         /// <returns>The value of the current <see cref="IAnyOf"/> object.</returns>
-        object Value { get; }
+        object? Value { get; }
 
         /// <summary>Gets the type of the current <see cref="IAnyOf"/> object.</summary>
         /// <returns>The type of the current <see cref="IAnyOf"/> object.</returns>
-        Type Type { get; }
+        Type? Type { get; }
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/AllowedValuesAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/AllowedValuesAttribute.cs
@@ -11,7 +11,6 @@ namespace System.ComponentModel.DataAnnotations
     public class AllowedValuesAttribute : ValidationAttribute
     {
         private readonly IEnumerable<object> allowedValues;
-        private readonly IEqualityComparer<object> comparer = EqualityComparer<object>.Default;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AllowedValuesAttribute"/> class.
@@ -26,6 +25,12 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public AllowedValuesAttribute(params object[] allowedValues) : this(allowedValues.AsEnumerable()) { }
 
+        /// <summary>
+        /// An equality comparer to compare values.
+        /// Defaults to <see cref="EqualityComparer{T}.Default"/>.
+        /// </summary>
+        public IEqualityComparer<object> Comparer { get; set; } = EqualityComparer<object>.Default;
+
         /// <inheritdoc/>
         public override bool IsValid(object? value)
         {
@@ -37,7 +42,7 @@ namespace System.ComponentModel.DataAnnotations
                 : new List<object> { value };
 
             // find the values not allowed
-            var unknown = values.Where(o => !allowedValues.Contains(o, comparer: comparer))
+            var unknown = values.Where(o => !allowedValues.Contains(o, comparer: Comparer))
                                 .ToList();
 
             // succeed only if there no unknown values

--- a/src/Tingle.Extensions.DataAnnotations/AllowedValuesAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/AllowedValuesAttribute.cs
@@ -26,19 +26,10 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public AllowedValuesAttribute(params object[] allowedValues) : this(allowedValues.AsEnumerable()) { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        public override bool IsValid(object? value)
         {
-            if (value is null) return ValidationResult.Success;
+            if (value is null) return true;
 
             // if the value is an enumerable, create values from each, otherwise its just the value
             var values = !(value is string) && value is IEnumerable ie
@@ -49,16 +40,8 @@ namespace System.ComponentModel.DataAnnotations
             var unknown = values.Where(o => !allowedValues.Contains(o, comparer: comparer))
                                 .ToList();
 
-            // if there are any, create validation error
-            if (unknown.Any())
-            {
-                var em = string.Format(ErrorMessageString, string.Join(",", unknown), validationContext.DisplayName);
-                return new ValidationResult(errorMessage: em,
-                                            memberNames: new string[] { validationContext.MemberName });
-            }
-
-            // any other value type just passes
-            return ValidationResult.Success;
+            // succeed only if there no unknown values
+            return !unknown.Any();
         }
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/AllowedValuesAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/AllowedValuesAttribute.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         /// Initializes a new instance of the <see cref="AllowedValuesAttribute"/> class.
         /// </summary>
-        public AllowedValuesAttribute(IEnumerable<object> allowedValues) : base("The value(s) '{0}' is/are not allowed for field {1}.")
+        public AllowedValuesAttribute(IEnumerable<object> allowedValues) : base("The field {0} only permits: {1}.")
         {
             this.allowedValues = allowedValues ?? throw new ArgumentNullException(nameof(allowedValues));
         }
@@ -30,6 +30,13 @@ namespace System.ComponentModel.DataAnnotations
         /// Defaults to <see cref="EqualityComparer{T}.Default"/>.
         /// </summary>
         public IEqualityComparer<object> Comparer { get; set; } = EqualityComparer<object>.Default;
+
+        /// <summary>
+        /// Formats the error message to display if the validation fails.
+        /// </summary>
+        /// <param name="name">The name of the field that caused the validation failure.</param>
+        /// <returns>The formatted error message.</returns>
+        public override string FormatErrorMessage(string name) => string.Format(ErrorMessageString, name, string.Join(",", allowedValues));
 
         /// <inheritdoc/>
         public override bool IsValid(object? value)

--- a/src/Tingle.Extensions.DataAnnotations/Base64Attribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/Base64Attribute.cs
@@ -11,32 +11,19 @@
         /// </summary>
         public Base64Attribute() : base("The field {0} must be a valid base64 string.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        public override bool IsValid(object? value)
         {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (string.IsNullOrEmpty(s)) return ValidationResult.Success;
-
+            if (value is not string s || string.IsNullOrEmpty(s)) return true;
             // attempt to convert from base64
             try
             {
                 _ = Convert.FromBase64String(s);
-                return ValidationResult.Success;
+                return true;
             }
             catch (Exception ex) when (ex is FormatException)
             {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
+                return false;
             }
         }
     }

--- a/src/Tingle.Extensions.DataAnnotations/DateMustBeInTheFutureAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/DateMustBeInTheFutureAttribute.cs
@@ -14,8 +14,8 @@
         /// <inheritdoc/>
         public override bool IsValid(object? value)
         {
-            return (value is DateTimeOffset dto && dto < DateTimeOffset.UtcNow)
-                || (value is DateTime dt && dt < DateTime.UtcNow);
+            return !((value is DateTimeOffset dto && dto < DateTimeOffset.UtcNow)
+                  || (value is DateTime dt && dt < DateTime.UtcNow));
         }
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/DateMustBeInTheFutureAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/DateMustBeInTheFutureAttribute.cs
@@ -11,28 +11,11 @@
         /// </summary>
         public DateMustBeInTheFutureAttribute() : base("The field {0} must be a date in the future.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        public override bool IsValid(object? value)
         {
-            // if the value is a valid date type and is in the past, validation fails
-            if ((value is DateTimeOffset dto && dto < DateTimeOffset.UtcNow)
-                || (value is DateTime dt && dt < DateTime.UtcNow))
-            {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
-            }
-
-            // any other value type just passes
-            return ValidationResult.Success;
+            return (value is DateTimeOffset dto && dto < DateTimeOffset.UtcNow)
+                || (value is DateTime dt && dt < DateTime.UtcNow);
         }
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/DateMustBeInThePastAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/DateMustBeInThePastAttribute.cs
@@ -14,8 +14,8 @@
         /// <inheritdoc/>
         public override bool IsValid(object? value)
         {
-            return (value is DateTimeOffset dto && dto > DateTimeOffset.UtcNow)
-                || (value is DateTime dt && dt > DateTime.UtcNow);
+            return !((value is DateTimeOffset dto && dto > DateTimeOffset.UtcNow)
+                  || (value is DateTime dt && dt > DateTime.UtcNow));
         }
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/DateMustBeInThePastAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/DateMustBeInThePastAttribute.cs
@@ -11,28 +11,11 @@
         /// </summary>
         public DateMustBeInThePastAttribute() : base("The field {0} must be a date in the past.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        public override bool IsValid(object? value)
         {
-            // if the value is a valid date type and is in the future, validation fails
-            if ((value is DateTimeOffset dto && dto > DateTimeOffset.UtcNow)
-                || (value is DateTime dt && dt > DateTime.UtcNow))
-            {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
-            }
-
-            // any other value type just passes
-            return ValidationResult.Success;
+            return (value is DateTimeOffset dto && dto > DateTimeOffset.UtcNow)
+                || (value is DateTime dt && dt > DateTime.UtcNow);
         }
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/PrefixAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/PrefixAttribute.cs
@@ -30,6 +30,6 @@
         public override string FormatErrorMessage(string name) => string.Format(ErrorMessageString, name, prefix);
 
         /// <inheritdoc/>
-        public override bool IsValid(object? value) => value is not string s || string.IsNullOrEmpty(s) || s.StartsWith(prefix, Comparison);
+        public override bool IsValid(object? value) => value is not string s || s == null || s.StartsWith(prefix, Comparison);
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/PrefixAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/PrefixAttribute.cs
@@ -23,34 +23,13 @@
         public StringComparison Comparison { get; set; } = StringComparison.CurrentCulture;
 
         /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-        {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (s == null) return ValidationResult.Success;
-
-            // check if the string starts with the prefix
-            if (s.StartsWith(prefix, Comparison)) return ValidationResult.Success;
-
-            // at this point, we can only fail
-            return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                        memberNames: new string[] { validationContext.MemberName });
-        }
-
-        /// <summary>
         /// Formats the error message to display if the validation fails.
         /// </summary>
         /// <param name="name">The name of the field that caused the validation failure.</param>
         /// <returns>The formatted error message.</returns>
         public override string FormatErrorMessage(string name) => string.Format(ErrorMessageString, name, prefix);
+
+        /// <inheritdoc/>
+        public override bool IsValid(object? value) => value is not string s || string.IsNullOrEmpty(s) || s.StartsWith(prefix, Comparison);
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/RecursiveValidator.cs
+++ b/src/Tingle.Extensions.DataAnnotations/RecursiveValidator.cs
@@ -24,7 +24,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <exception cref="ArgumentNullException">instance is null.</exception>
         public static bool TryValidateObject(object instance,
                                              ICollection<ValidationResult> validationResults,
-                                             IDictionary<object, object> validationContextItems = null)
+                                             IDictionary<object, object?>? validationContextItems = null)
         {
             var context = new ValidationContext(instance, null, validationContextItems);
             return Validator.TryValidateObject(instance: instance,
@@ -42,7 +42,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </param>
         /// <exception cref="ValidationException">instance is not valid.</exception>
         /// <exception cref="ArgumentNullException">instance is null.</exception>
-        public static void ValidateObject(object instance, IDictionary<object, object> validationContextItems = null)
+        public static void ValidateObject(object instance, IDictionary<object, object?>? validationContextItems = null)
         {
             var context = new ValidationContext(instance, null, validationContextItems);
             Validator.ValidateObject(instance: instance,
@@ -63,7 +63,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <exception cref="ArgumentNullException">instance is null.</exception>
         public static bool TryValidateObjectRecursive(object instance,
                                                       ICollection<ValidationResult> validationResults,
-                                                      IDictionary<object, object> validationContextItems = null)
+                                                      IDictionary<object, object?>? validationContextItems = null)
         {
             return TryValidateObjectRecursive(instance: instance,
                                               validationResults: validationResults,
@@ -80,7 +80,7 @@ namespace System.ComponentModel.DataAnnotations
         /// </param>
         /// <exception cref="ValidationException">instance is not valid.</exception>
         /// <exception cref="ArgumentNullException">instance is null.</exception>
-        public static void ValidateObjectRecursive(object instance, IDictionary<object, object> validationContextItems = null)
+        public static void ValidateObjectRecursive(object instance, IDictionary<object, object?>? validationContextItems = null)
         {
             ValidateObjectRecursive(instance: instance,
                                     validatedObjects: new HashSet<object>(),
@@ -90,7 +90,7 @@ namespace System.ComponentModel.DataAnnotations
         private static bool TryValidateObjectRecursive(object instance,
                                                        ICollection<ValidationResult> validationResults,
                                                        ISet<object> validatedObjects,
-                                                       IDictionary<object, object> validationContextItems = null)
+                                                       IDictionary<object, object?>? validationContextItems = null)
         {
             //short-circuit to avoid infinit loops on cyclical object graphs
             if (validatedObjects.Contains(instance))
@@ -152,7 +152,7 @@ namespace System.ComponentModel.DataAnnotations
 
         private static void ValidateObjectRecursive(object instance,
                                                     ISet<object> validatedObjects,
-                                                    IDictionary<object, object> validationContextItems = null)
+                                                    IDictionary<object, object?>? validationContextItems = null)
         {
             //short-circuit to avoid infinit loops on cyclical object graphs
             if (validatedObjects.Contains(instance))

--- a/src/Tingle.Extensions.DataAnnotations/SuffixAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/SuffixAttribute.cs
@@ -23,34 +23,13 @@
         public StringComparison Comparison { get; set; } = StringComparison.CurrentCulture;
 
         /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-        {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (s == null) return ValidationResult.Success;
-
-            // check if the string ends with the suffix
-            if (s.EndsWith(suffix, Comparison)) return ValidationResult.Success;
-
-            // at this point, we can only fail
-            return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                        memberNames: new string[] { validationContext.MemberName });
-        }
-
-        /// <summary>
         /// Formats the error message to display if the validation fails.
         /// </summary>
         /// <param name="name">The name of the field that caused the validation failure.</param>
         /// <returns>The formatted error message.</returns>
         public override string FormatErrorMessage(string name) => string.Format(ErrorMessageString, name, suffix);
+
+        /// <inheritdoc/>
+        public override bool IsValid(object? value) => value is not string s || string.IsNullOrEmpty(s) || s.EndsWith(suffix, Comparison);
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/SuffixAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/SuffixAttribute.cs
@@ -30,6 +30,6 @@
         public override string FormatErrorMessage(string name) => string.Format(ErrorMessageString, name, suffix);
 
         /// <inheritdoc/>
-        public override bool IsValid(object? value) => value is not string s || string.IsNullOrEmpty(s) || s.EndsWith(suffix, Comparison);
+        public override bool IsValid(object? value) => value is not string s || s == null || s.EndsWith(suffix, Comparison);
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/TimeZoneAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/TimeZoneAttribute.cs
@@ -14,32 +14,10 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public TimeZoneAttribute() : base("The field {0} must be a valid Windows or IANA TimeZone identifier.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        public override bool IsValid(object? value)
         {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (string.IsNullOrEmpty(s)) return ValidationResult.Success;
-
-            // Validate the TimeZone
-            if (TZConvert.TryGetTimeZoneInfo(windowsOrIanaTimeZoneId: s, timeZoneInfo: out _))
-            {
-                return ValidationResult.Success;
-            }
-            else
-            {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new[] { validationContext.MemberName });
-            }
+            return value is not string s || string.IsNullOrEmpty(s) || TZConvert.TryGetTimeZoneInfo(windowsOrIanaTimeZoneId: s, out _);
         }
     }
 }

--- a/src/Tingle.Extensions.Json/JsonSerializerOptionsExtensions.cs
+++ b/src/Tingle.Extensions.Json/JsonSerializerOptionsExtensions.cs
@@ -62,10 +62,10 @@ namespace System.Text.Json
         /// <param name="namingPolicy">the naming policy, if not set, the one in the options is used</param>
         /// <returns></returns>
         public static JsonSerializerOptions AddConverterForEnumsAsStrings(this JsonSerializerOptions options,
-                                                                          JsonNamingPolicy namingPolicy = null)
+                                                                          JsonNamingPolicy? namingPolicy = null)
         {
             options.Converters.Add(new JsonStringEnumConverter(namingPolicy ?? options?.PropertyNamingPolicy));
-            return options;
+            return options!;
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace System.Text.Json
         /// <param name="namingPolicy">the naming policy, if not set, the one in the options is used</param>
         /// <returns></returns>
         public static JsonSerializerOptions AddKnownConverters(this JsonSerializerOptions options,
-                                                               JsonNamingPolicy namingPolicy = null)
+                                                               JsonNamingPolicy? namingPolicy = null)
         {
             return options.AddConverterForTimeSpan()
                           .AddConverterForVersion()

--- a/src/Tingle.Extensions.Json/ObjectExtensions.cs
+++ b/src/Tingle.Extensions.Json/ObjectExtensions.cs
@@ -16,8 +16,8 @@ namespace System
         /// <param name="source">the source of the data</param>
         /// <param name="options">the serialization settings if any</param>
         /// <returns></returns>
-        public static T JsonClone<T>(this T source, JsonSerializerOptions options = null)
-                where T : class
+        public static T? JsonClone<T>(this T? source, JsonSerializerOptions? options = null)
+            where T : class
         {
             if (source == default) return default;
             var json = JsonSerializer.Serialize(source, options ?? JsonHelper.DefaultOptions);
@@ -48,7 +48,7 @@ namespace System
         /// <param name="source">the source of the data</param>
         /// <param name="options">the serialization settings if any</param>
         /// <returns></returns>
-        public static T JsonConvertTo<T>(this object source, JsonSerializerOptions options = null)
+        public static T? JsonConvertTo<T>(this object? source, JsonSerializerOptions? options = null)
         {
             if (source == default) return default;
             var json = JsonSerializer.Serialize(source, options ?? JsonHelper.DefaultOptions);

--- a/src/Tingle.Extensions.Json/TimeSpanConverter.cs
+++ b/src/Tingle.Extensions.Json/TimeSpanConverter.cs
@@ -25,12 +25,6 @@ namespace Tingle.Extensions.Json
         /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
         {
-            if (value == null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-
             writer.WriteStringValue(value.ToString());
         }
     }

--- a/src/Tingle.Extensions.Json/VersionConverter.cs
+++ b/src/Tingle.Extensions.Json/VersionConverter.cs
@@ -13,13 +13,13 @@ namespace Tingle.Extensions.Json
         public override Version Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             // only support from string
-            if (reader.TokenType == JsonTokenType.String)
+            if (reader.TokenType != JsonTokenType.String)
             {
+                throw new InvalidOperationException("Only strings are supported");
+            }
                 var s = reader.GetString();
                 return Version.Parse(s);
-            }
 
-            return default;
         }
 
         /// <inheritdoc/>

--- a/src/Tingle.Extensions.Json/VersionConverter.cs
+++ b/src/Tingle.Extensions.Json/VersionConverter.cs
@@ -10,16 +10,17 @@ namespace Tingle.Extensions.Json
     public class VersionConverter : JsonConverter<Version>
     {
         /// <inheritdoc/>
-        public override Version Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override Version? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             // only support from string
+            if (reader.TokenType == JsonTokenType.Null) return default;
             if (reader.TokenType != JsonTokenType.String)
             {
                 throw new InvalidOperationException("Only strings are supported");
             }
-                var s = reader.GetString();
-                return Version.Parse(s);
 
+            var s = reader.GetString();
+            return Version.Parse(s);
         }
 
         /// <inheritdoc/>

--- a/src/Tingle.Extensions.JsonPatch/Converters/JsonPatchDocumentConverter.cs
+++ b/src/Tingle.Extensions.JsonPatch/Converters/JsonPatchDocumentConverter.cs
@@ -8,19 +8,20 @@ namespace Tingle.Extensions.JsonPatch.Converters
 {
     public class JsonPatchDocumentConverter : JsonConverter<JsonPatchDocument>
     {
-        public override JsonPatchDocument Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        /// <inheritdoc/>
+        public override JsonPatchDocument? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.Null)
-                return null;
+            if (reader.TokenType == JsonTokenType.Null) return default;
 
             var targetOperations = JsonSerializer.Deserialize<List<Operation>>(ref reader, options);
 
             // container target: the JsonPatchDocument. 
-            var container = new JsonPatchDocument(targetOperations);
+            var container = new JsonPatchDocument(targetOperations ?? new List<Operation>());
 
             return container;
         }
 
+        /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, JsonPatchDocument value, JsonSerializerOptions options)
         {
             // we write an array of the operations

--- a/src/Tingle.Extensions.JsonPatch/Converters/TypedJsonPatchDocumentConverter.cs
+++ b/src/Tingle.Extensions.JsonPatch/Converters/TypedJsonPatchDocumentConverter.cs
@@ -13,7 +13,7 @@ namespace Tingle.Extensions.JsonPatch.Converters
             return typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>);
         }
 
-        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             var modelType = typeToConvert.GetGenericArguments()[0];
             var conveterType = typeof(TypedJsonPatchDocumentConverterInner<>).MakeGenericType(modelType);
@@ -22,15 +22,16 @@ namespace Tingle.Extensions.JsonPatch.Converters
 
         internal class TypedJsonPatchDocumentConverterInner<T> : JsonConverter<JsonPatchDocument<T>> where T : class
         {
-            public override JsonPatchDocument<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            /// <inheritdoc/>
+            public override JsonPatchDocument<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                if (reader.TokenType == JsonTokenType.Null)
-                    return null;
+                if (reader.TokenType == JsonTokenType.Null) return default;
 
                 var operations = JsonSerializer.Deserialize<List<Operation<T>>>(ref reader, options);
-                return new JsonPatchDocument<T>(operations);
+                return new JsonPatchDocument<T>(operations ?? new List<Operation<T>>());
             }
 
+            /// <inheritdoc/>
             public override void Write(Utf8JsonWriter writer, JsonPatchDocument<T> value, JsonSerializerOptions options)
             {
                 // we write an array of the operations

--- a/src/Tingle.Extensions.JsonPatch/Exceptions/JsonPatchException.cs
+++ b/src/Tingle.Extensions.JsonPatch/Exceptions/JsonPatchException.cs
@@ -5,13 +5,13 @@ namespace Tingle.Extensions.JsonPatch.Exceptions
 {
     public class JsonPatchException : Exception
     {
-        public Operation FailedOperation { get; private set; }
-        public object AffectedObject { get; private set; }
+        public Operation? FailedOperation { get; private set; }
+        public object? AffectedObject { get; private set; }
 
 
         public JsonPatchException() { }
 
-        public JsonPatchException(JsonPatchError jsonPatchError, Exception innerException)
+        public JsonPatchException(JsonPatchError jsonPatchError, Exception? innerException)
             : base(jsonPatchError.ErrorMessage, innerException)
         {
             FailedOperation = jsonPatchError.Operation;
@@ -20,6 +20,6 @@ namespace Tingle.Extensions.JsonPatch.Exceptions
 
         public JsonPatchException(JsonPatchError jsonPatchError) : this(jsonPatchError, null) { }
 
-        public JsonPatchException(string message, Exception innerException) : base(message, innerException) { }
+        public JsonPatchException(string message, Exception? innerException) : base(message, innerException) { }
     }
 }

--- a/src/Tingle.Extensions.JsonPatch/Helpers/ExpressionHelpers.cs
+++ b/src/Tingle.Extensions.JsonPatch/Helpers/ExpressionHelpers.cs
@@ -141,27 +141,14 @@ namespace Tingle.Extensions.JsonPatch.Helpers
         {
 
             if (string.IsNullOrWhiteSpace(propertyName)) return propertyName;
-
-            string result;
-
-            switch (type)
+            string result = type switch
             {
-                case CaseTransformType.CamelCase:
-                    result = char.ToLowerInvariant(propertyName[0]) + propertyName.Substring(1);
-                    break;
-                case CaseTransformType.LowerCase:
-                    result = propertyName.ToLowerInvariant();
-                    break;
-                case CaseTransformType.UpperCase:
-                    result = propertyName.ToUpperInvariant();
-                    break;
-                case CaseTransformType.OriginalCase:
-                    result = propertyName;
-                    break;
-                default:
-                    throw new NotImplementedException();
-            }
-
+                CaseTransformType.CamelCase => char.ToLowerInvariant(propertyName[0]) + propertyName.Substring(1),
+                CaseTransformType.LowerCase => propertyName.ToLowerInvariant(),
+                CaseTransformType.UpperCase => propertyName.ToUpperInvariant(),
+                CaseTransformType.OriginalCase => propertyName,
+                _ => throw new NotImplementedException(),
+            };
             return result;
         }
     }

--- a/src/Tingle.Extensions.JsonPatch/Helpers/ExpressionHelpers.cs
+++ b/src/Tingle.Extensions.JsonPatch/Helpers/ExpressionHelpers.cs
@@ -23,7 +23,7 @@ namespace Tingle.Extensions.JsonPatch.Helpers
             return "/" + GetPath(expr.Body, caseTransformType, true);
         }
 
-        private static string GetPath(Expression expr, CaseTransformType caseTransformType, bool firstTime)
+        private static string? GetPath(Expression expr, CaseTransformType caseTransformType, bool firstTime)
         {
             switch (expr.NodeType)
             {
@@ -58,7 +58,7 @@ namespace Tingle.Extensions.JsonPatch.Helpers
                     return GetPath(((UnaryExpression)expr).Operand, caseTransformType, false);
 
                 case ExpressionType.MemberAccess:
-                    var memberExpression = expr as MemberExpression;
+                    var memberExpression = (MemberExpression)expr;
 
                     if (ContinueWithSubPath(memberExpression.Expression.NodeType, false))
                     {
@@ -74,7 +74,7 @@ namespace Tingle.Extensions.JsonPatch.Helpers
                         if (jsonPropertyAttribute.Length > 0)
                         {
                             // get value
-                            var castedAttribrute = jsonPropertyAttribute[0] as JsonPropertyNameAttribute;
+                            var castedAttribrute = (JsonPropertyNameAttribute)jsonPropertyAttribute[0];
                             return left + "/" + CaseTransform(castedAttribrute.Name, caseTransformType);
                         }
 
@@ -92,7 +92,7 @@ namespace Tingle.Extensions.JsonPatch.Helpers
                         if (jsonPropertyAttribute.Length > 0)
                         {
                             // get value
-                            var castedAttribrute = jsonPropertyAttribute[0] as JsonPropertyNameAttribute;
+                            var castedAttribrute = (JsonPropertyNameAttribute)jsonPropertyAttribute[0];
                             return CaseTransform(castedAttribrute.Name, caseTransformType);
                         }
 
@@ -131,11 +131,9 @@ namespace Tingle.Extensions.JsonPatch.Helpers
         {
             var converted = Expression.Convert(expression, typeof(object));
             var fakeParameter = Expression.Parameter(typeof(object), null);
-            var lambda = Expression.Lambda<Func<object, object>>(converted, fakeParameter);
-            Func<object, object> func;
+            var lambda = Expression.Lambda<Func<object?, object>>(converted, fakeParameter);
 
-            func = lambda.Compile();
-
+            var func = lambda.Compile();
             return Convert.ToString(func(null), CultureInfo.InvariantCulture);
         }
 

--- a/src/Tingle.Extensions.JsonPatch/Internal/ConversionResult.cs
+++ b/src/Tingle.Extensions.JsonPatch/Internal/ConversionResult.cs
@@ -6,13 +6,13 @@
     /// </summary>
     public class ConversionResult
     {
-        public ConversionResult(bool canBeConverted, object convertedInstance)
+        public ConversionResult(bool canBeConverted, object? convertedInstance)
         {
             CanBeConverted = canBeConverted;
             ConvertedInstance = convertedInstance;
         }
 
         public bool CanBeConverted { get; }
-        public object ConvertedInstance { get; }
+        public object? ConvertedInstance { get; }
     }
 }

--- a/src/Tingle.Extensions.JsonPatch/Internal/ParsedPath.cs
+++ b/src/Tingle.Extensions.JsonPatch/Internal/ParsedPath.cs
@@ -12,8 +12,6 @@ namespace Tingle.Extensions.JsonPatch.Internal
     /// </summary>
     public readonly struct ParsedPath
     {
-        private static readonly string[] Empty = null;
-
         private readonly string[] _segments;
 
         public ParsedPath(string path)
@@ -39,7 +37,7 @@ namespace Tingle.Extensions.JsonPatch.Internal
             }
         }
 
-        public IReadOnlyList<string> Segments => _segments ?? Empty;
+        public IReadOnlyList<string> Segments => _segments ?? Array.Empty<string>();
 
         private static string[] ParsePath(string path)
         {

--- a/src/Tingle.Extensions.JsonPatch/Internal/ParsedPath.cs
+++ b/src/Tingle.Extensions.JsonPatch/Internal/ParsedPath.cs
@@ -26,7 +26,7 @@ namespace Tingle.Extensions.JsonPatch.Internal
             _segments = ParsePath(path);
         }
 
-        public string LastSegment
+        public string? LastSegment
         {
             get
             {

--- a/src/Tingle.Extensions.JsonPatch/JsonPatchDocumentOfT.cs
+++ b/src/Tingle.Extensions.JsonPatch/JsonPatchDocumentOfT.cs
@@ -790,7 +790,7 @@ namespace Tingle.Extensions.JsonPatch
         }
 
         // Internal for testing
-        internal string GetPath<TProp>(Expression<Func<TModel, TProp>> expr, string position)
+        internal string GetPath<TProp>(Expression<Func<TModel, TProp>> expr, string? position)
         {
             var segments = GetPathSegments(expr.Body);
             var path = string.Join("/", segments);
@@ -828,7 +828,7 @@ namespace Tingle.Extensions.JsonPatch
                     return listOfSegments;
 
                 case ExpressionType.MemberAccess:
-                    var memberExpression = expr as MemberExpression;
+                    var memberExpression = (MemberExpression)expr;
                     listOfSegments.AddRange(GetPathSegments(memberExpression.Expression));
                     // Get property name, respecting JsonProperty attribute
                     listOfSegments.Add(ExpressionHelpers.CaseTransform(GetPropertyNameFromMemberExpression(memberExpression), CaseTransformType));
@@ -869,7 +869,7 @@ namespace Tingle.Extensions.JsonPatch
         {
             var converted = Expression.Convert(expression, typeof(object));
             var fakeParameter = Expression.Parameter(typeof(object), null);
-            var lambda = Expression.Lambda<Func<object, object>>(converted, fakeParameter);
+            var lambda = Expression.Lambda<Func<object?, object>>(converted, fakeParameter);
             var func = lambda.Compile();
 
             return Convert.ToString(func(null), CultureInfo.InvariantCulture);

--- a/src/Tingle.Extensions.JsonPatch/Operations/Operation.cs
+++ b/src/Tingle.Extensions.JsonPatch/Operations/Operation.cs
@@ -8,16 +8,16 @@ namespace Tingle.Extensions.JsonPatch.Operations
     public class Operation : OperationBase
     {
         [JsonPropertyName("value")]
-        public object value { get; set; }
+        public object? value { get; set; }
 
         public Operation() { }
 
-        public Operation(string op, string path, string from, object value) : base(op, path, from)
+        public Operation(string op, string path, string? from, object? value) : base(op, path, from)
         {
             this.value = value;
         }
 
-        public Operation(string op, string path, string from) : base(op, path, from) { }
+        public Operation(string op, string path, string? from) : base(op, path, from) { }
 
         public void Apply(object objectToApplyTo, IObjectAdapter adapter)
         {

--- a/src/Tingle.Extensions.JsonPatch/Operations/OperationBase.cs
+++ b/src/Tingle.Extensions.JsonPatch/Operations/OperationBase.cs
@@ -5,7 +5,7 @@ namespace Tingle.Extensions.JsonPatch.Operations
 {
     public class OperationBase
     {
-        private string _op;
+        private string? _op;
         private OperationType _operationType;
 
         [JsonIgnore]
@@ -18,10 +18,10 @@ namespace Tingle.Extensions.JsonPatch.Operations
         }
 
         [JsonPropertyName("path")]
-        public string path { get; set; }
+        public string? path { get; set; }
 
         [JsonPropertyName("op")]
-        public string op
+        public string? op
         {
             get
             {
@@ -39,11 +39,11 @@ namespace Tingle.Extensions.JsonPatch.Operations
         }
 
         [JsonPropertyName("from")]
-        public string from { get; set; }
+        public string? from { get; set; }
 
         public OperationBase() { }
 
-        public OperationBase(string op, string path, string from)
+        public OperationBase(string op, string path, string? from)
         {
             this.op = op ?? throw new ArgumentNullException(nameof(op));
             this.path = path ?? throw new ArgumentNullException(nameof(path));

--- a/src/Tingle.Extensions.JsonPatch/Operations/OperationOfT.cs
+++ b/src/Tingle.Extensions.JsonPatch/Operations/OperationOfT.cs
@@ -9,7 +9,7 @@ namespace Tingle.Extensions.JsonPatch.Operations
     {
         public Operation() { }
 
-        public Operation(string op, string path, string from, object value) : base(op, path, from)
+        public Operation(string op, string path, string? from, object? value) : base(op, path, from)
         {
             if (op == null) throw new ArgumentNullException(nameof(op));
             if (path == null) throw new ArgumentNullException(nameof(path));
@@ -17,7 +17,7 @@ namespace Tingle.Extensions.JsonPatch.Operations
             this.value = value;
         }
 
-        public Operation(string op, string path, string from) : base(op, path, from)
+        public Operation(string op, string path, string? from) : base(op, path, from)
         {
             if (op == null) throw new ArgumentNullException(nameof(op));
             if (path == null) throw new ArgumentNullException(nameof(path));

--- a/src/Tingle.Extensions.Logging.LogAnalytics/HttpClientExtensions.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/HttpClientExtensions.cs
@@ -85,11 +85,9 @@ namespace System.Net.Http
         {
             var stringToHash = string.Join("\n", method, contentLength, contentType, $"{DateHeaderName}:{date}", resource);
             var bytesToHash = Encoding.ASCII.GetBytes(stringToHash);
-            using (var sha256 = new HMACSHA256(key))
-            {
-                var calculatedHash = sha256.ComputeHash(bytesToHash);
-                return Convert.ToBase64String(calculatedHash);
-            }
+            using var sha256 = new HMACSHA256(key);
+            var calculatedHash = sha256.ComputeHash(bytesToHash);
+            return Convert.ToBase64String(calculatedHash);
         }
     }
 }

--- a/src/Tingle.Extensions.Logging.LogAnalytics/HttpClientExtensions.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/HttpClientExtensions.cs
@@ -36,11 +36,11 @@ namespace System.Net.Http
         }
 
         public static async Task UploadInnerAsync(this HttpClient httpClient,
-                                             string workspaceId,
-                                             byte[] workspaceKey,
-                                             string payload,
-                                             string logType,
-                                             DateTimeOffset? generated = null)
+                                                  string workspaceId,
+                                                  byte[] workspaceKey,
+                                                  string payload,
+                                                  string logType,
+                                                  DateTimeOffset? generated = null)
         {
             var encoding = Encoding.UTF8;
 

--- a/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLogger.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLogger.cs
@@ -30,7 +30,7 @@ namespace Tingle.Extensions.Logging.LogAnalytics
         /// <summary>
         /// Gets or sets the external scope provider.
         /// </summary>
-        internal IExternalScopeProvider ExternalScopeProvider { get; set; }
+        internal IExternalScopeProvider? ExternalScopeProvider { get; set; }
 
         ///<inheritdoc/>
         public IDisposable BeginScope<TState>(TState state) => ExternalScopeProvider?.Push(state) ?? NullScope.Instance;
@@ -124,7 +124,7 @@ namespace Tingle.Extensions.Logging.LogAnalytics
                     // Create payload in JSON and key from Base64
                     var payload = System.Text.Json.JsonSerializer.Serialize(data);
                     var key = Convert.FromBase64String(options.WorkspaceKey);
-                    var tsk = httpClient.UploadAsync(workspaceId: options.WorkspaceId,
+                    var tsk = httpClient.UploadAsync(workspaceId: options.WorkspaceId!,
                                                      workspaceKey: key,
                                                      payload: payload,
                                                      logType: options.LogTypeName,

--- a/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerEventSource.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerEventSource.cs
@@ -9,7 +9,7 @@ namespace Tingle.Extensions.Logging.LogAnalytics
     [EventSource(Name = "Tingle-LogAnalytics-LoggerProvider")]
     internal class LogAnalyticsLoggerEventSource : EventSource
     {
-        public static readonly LogAnalyticsLoggerEventSource Log = new LogAnalyticsLoggerEventSource();
+        public static readonly LogAnalyticsLoggerEventSource Log = new();
         public readonly string ApplicationName;
 
         private LogAnalyticsLoggerEventSource()

--- a/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerEventSource.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerEventSource.cs
@@ -18,7 +18,7 @@ namespace Tingle.Extensions.Logging.LogAnalytics
         }
 
         [Event(1, Message = "Sending log to LogAnalyticsLoggerProvider has failed. Error: {0}", Level = EventLevel.Error)]
-        public void FailedToLog(string error, string applicationName = null) => WriteEvent(1, error, applicationName ?? ApplicationName);
+        public void FailedToLog(string error, string? applicationName = null) => WriteEvent(1, error, applicationName ?? ApplicationName);
 
         [NonEvent]
         private static string GetApplicationName()

--- a/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerException.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerException.cs
@@ -5,20 +5,12 @@ namespace Tingle.Extensions.Logging.LogAnalytics
 {
     internal class LogAnalyticsLoggerException : Exception
     {
-        public LogAnalyticsLoggerException(string message) : base(message)
-        {
-        }
+        public LogAnalyticsLoggerException(string message) : base(message) { }
 
-        public LogAnalyticsLoggerException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+        public LogAnalyticsLoggerException(string message, Exception innerException) : base(message, innerException) { }
 
-        public LogAnalyticsLoggerException()
-        {
-        }
+        public LogAnalyticsLoggerException() { }
 
-        protected LogAnalyticsLoggerException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
+        protected LogAnalyticsLoggerException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerOptions.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerOptions.cs
@@ -8,12 +8,12 @@
         /// <summary>
         /// Gets or sets the unique identifier of the LogAnalytics workspace.
         /// </summary>
-        public string WorkspaceId { get; set; }
+        public string? WorkspaceId { get; set; }
 
         /// <summary>
         /// Gets or sets the key for authentication against the LogAnalytics endpoint.
         /// </summary>
-        public string WorkspaceKey { get; set; }
+        public string? WorkspaceKey { get; set; }
 
         /// <summary>
         /// Gets or sets the name that appears appear on LogAnalytics navigation menu.

--- a/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerProvider.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/LogAnalyticsLoggerProvider.cs
@@ -16,7 +16,7 @@ namespace Tingle.Extensions.Logging.LogAnalytics
         // The LogAnalytics logger options.
         private readonly LogAnalyticsLoggerOptions options;
         // The external scope provider to allow setting scope data in messages.
-        private IExternalScopeProvider externalScopeProvider;
+        private IExternalScopeProvider? externalScopeProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogAnalyticsLoggerProvider"/> class.

--- a/src/Tingle.Extensions.Logging.LogAnalytics/NullScope.cs
+++ b/src/Tingle.Extensions.Logging.LogAnalytics/NullScope.cs
@@ -7,17 +7,13 @@ namespace Tingle.Extensions.Logging.LogAnalytics
     /// </summary>
     internal class NullScope : IDisposable
     {
-        private NullScope()
-        {
-        }
+        private NullScope() { }
 
         public static NullScope Instance { get; } = new NullScope();
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        public void Dispose()
-        {
-        }
+        public void Dispose() { }
     }
 }

--- a/src/Tingle.Extensions.PhoneValidators/Abstractions/AbstractPhoneNumberValidator.cs
+++ b/src/Tingle.Extensions.PhoneValidators/Abstractions/AbstractPhoneNumberValidator.cs
@@ -29,7 +29,7 @@ namespace Tingle.Extensions.PhoneValidators.Abstractions
         }
 
         /// <inheritdoc/>
-        public IEnumerable<string> MakePossibleValues(string phoneNumber)
+        public IEnumerable<string>? MakePossibleValues(string phoneNumber)
         {
             if (string.IsNullOrWhiteSpace(phoneNumber)) return null;
 
@@ -41,7 +41,7 @@ namespace Tingle.Extensions.PhoneValidators.Abstractions
         }
 
         /// <inheritdoc/>
-        public string ToMsisdn(string phoneNumber)
+        public string? ToMsisdn(string phoneNumber)
         {
             if (string.IsNullOrWhiteSpace(phoneNumber)) return null;
 
@@ -52,7 +52,7 @@ namespace Tingle.Extensions.PhoneValidators.Abstractions
         }
 
         /// <inheritdoc/>
-        public string ToE164(string phoneNumber)
+        public string? ToE164(string phoneNumber)
         {
             if (string.IsNullOrWhiteSpace(phoneNumber)) return null;
 

--- a/src/Tingle.Extensions.PhoneValidators/Airtel/AirtelPhoneNumberAttribute.cs
+++ b/src/Tingle.Extensions.PhoneValidators/Airtel/AirtelPhoneNumberAttribute.cs
@@ -9,39 +9,14 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class AirtelPhoneNumberAttribute : ValidationAttribute
     {
+        private static readonly Regex regex = new(AirtelPhoneNumberValidator.RegExComplete);
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SafaricomPhoneNumberAttribute"/> class.
         /// </summary>
         public AirtelPhoneNumberAttribute() : base("The field {0} must be a valid Airtel phone number.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-        {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (string.IsNullOrEmpty(s)) return ValidationResult.Success;
-
-            // check if phone number matches RegEx
-            var regex = new Regex(AirtelPhoneNumberValidator.RegExComplete);
-            if (regex.Match(s).Success)
-            {
-                return ValidationResult.Success;
-            }
-            else
-            {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
-            }
-        }
-
+        /// <inheritdoc/>
+        public override bool IsValid(object? value) => value is not string s || string.IsNullOrEmpty(s) || regex.Match(s).Success;
     }
 }

--- a/src/Tingle.Extensions.PhoneValidators/Airtel/AirtelPhoneNumberValidator.cs
+++ b/src/Tingle.Extensions.PhoneValidators/Airtel/AirtelPhoneNumberValidator.cs
@@ -16,7 +16,7 @@ namespace Tingle.Extensions.PhoneValidators.Airtel
         // The digits are 30-39, 50-56, 85-89 when prefixed with 7 and 00-02 when prefixed with 1
         internal const string RegExComplete = @"^(?:254|\+254|0)?((?:(?:7(?:(?:3[0-9])|(?:5[0-6])|(8[5-9])))|(?:1(?:[0][0-2])))[0-9]{6})$";
 
-        private static readonly Regex regex = new Regex(@RegExComplete);
+        private static readonly Regex regex = new(@RegExComplete);
 
         /// <summary>
         /// Creates an instance of <see cref="AirtelPhoneNumberValidator"/>

--- a/src/Tingle.Extensions.PhoneValidators/E164PhoneAttribute.cs
+++ b/src/Tingle.Extensions.PhoneValidators/E164PhoneAttribute.cs
@@ -8,7 +8,7 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class E164PhoneAttribute : ValidationAttribute
     {
-        private readonly string defaultRegion;
+        private readonly string? defaultRegion;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="E164PhoneAttribute"/> class.
@@ -20,7 +20,7 @@ namespace System.ComponentModel.DataAnnotations
         /// If the number is guaranteed to start with a '+' followed by the country calling
         /// code, then "ZZ" or null can be supplied.
         /// </param>
-        public E164PhoneAttribute(string defaultRegion = null) : base("The field {0} must be a valid E.164 phone number.")
+        public E164PhoneAttribute(string? defaultRegion = null) : base("The field {0} must be a valid E.164 phone number.")
         {
             this.defaultRegion = defaultRegion?.ToUpperInvariant();
 
@@ -33,33 +33,19 @@ namespace System.ComponentModel.DataAnnotations
             }
         }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        public override bool IsValid(object? value)
         {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (string.IsNullOrEmpty(s)) return ValidationResult.Success;
-
-            // attempt to parse phone number
+            if (value is not string s || string.IsNullOrEmpty(s)) return true;
             try
             {
                 var phoneNumberUtil = PhoneNumberUtil.GetInstance();
                 _ = phoneNumberUtil.Parse(numberToParse: s, defaultRegion: defaultRegion);
-                return ValidationResult.Success;
+                return true;
             }
             catch (Exception ex) when (ex is NumberParseException)
             {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
+                return false;
             }
         }
     }

--- a/src/Tingle.Extensions.PhoneValidators/IPhoneNumberValidator.cs
+++ b/src/Tingle.Extensions.PhoneValidators/IPhoneNumberValidator.cs
@@ -19,20 +19,20 @@ namespace Tingle.Extensions.PhoneValidators
         /// </summary>
         /// <param name="phoneNumber">The phone number.</param>
         /// <returns></returns>
-        string ToMsisdn(string phoneNumber);
+        string? ToMsisdn(string phoneNumber);
 
         /// <summary>
         /// Generate all possible values for a phone number
         /// </summary>
         /// <param name="phoneNumber">The phone number.</param>
         /// <returns></returns>
-        IEnumerable<string> MakePossibleValues(string phoneNumber);
+        IEnumerable<string>? MakePossibleValues(string phoneNumber);
 
         /// <summary>
         /// Make an <see href="https://en.wikipedia.org/wiki/E.164">E.164</see> version of a phone number.
         /// </summary>
         /// <param name="phoneNumber">The phone number.</param>
         /// <returns></returns>
-        string ToE164(string phoneNumber);
+        string? ToE164(string phoneNumber);
     }
 }

--- a/src/Tingle.Extensions.PhoneValidators/MsisdnPhoneAttribute.cs
+++ b/src/Tingle.Extensions.PhoneValidators/MsisdnPhoneAttribute.cs
@@ -17,6 +17,7 @@ namespace System.ComponentModel.DataAnnotations
         public override bool IsValid(object? value)
         {
             if (value is not string s || string.IsNullOrEmpty(s)) return true;
+            if (s.StartsWith("+")) return false;
             try
             {
                 var prepended = "+" + s;

--- a/src/Tingle.Extensions.PhoneValidators/MsisdnPhoneAttribute.cs
+++ b/src/Tingle.Extensions.PhoneValidators/MsisdnPhoneAttribute.cs
@@ -13,41 +13,20 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         public MsisdnPhoneAttribute() : base("The field {0} must be a valid MSISDN phone number.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        public override bool IsValid(object? value)
         {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (string.IsNullOrEmpty(s)) return ValidationResult.Success;
-
-            // if the value already starts with a plus, we have failed
-            if (s.StartsWith("+"))
-            {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
-            }
-
-            // attempt to parse phone number
+            if (value is not string s || string.IsNullOrEmpty(s)) return true;
             try
             {
                 var prepended = "+" + s;
                 var phoneNumberUtil = PhoneNumberUtil.GetInstance();
                 _ = phoneNumberUtil.Parse(numberToParse: prepended, defaultRegion: null);
-                return ValidationResult.Success;
+                return true;
             }
             catch (Exception ex) when (ex is NumberParseException)
             {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
+                return false;
             }
         }
     }

--- a/src/Tingle.Extensions.PhoneValidators/Safaricom/SafaricomPhoneNumberAttribute.cs
+++ b/src/Tingle.Extensions.PhoneValidators/Safaricom/SafaricomPhoneNumberAttribute.cs
@@ -9,39 +9,14 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class SafaricomPhoneNumberAttribute : ValidationAttribute
     {
+        private static readonly Regex regex = new(SafaricomPhoneNumberValidator.RegExComplete);
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SafaricomPhoneNumberAttribute"/> class.
         /// </summary>
         public SafaricomPhoneNumberAttribute() : base("The field {0} must be a valid Safaricom phone number.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-        {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (string.IsNullOrEmpty(s)) return ValidationResult.Success;
-
-            // check if phone number matches RegEx
-            var regex = new Regex(SafaricomPhoneNumberValidator.RegExComplete);
-            if (regex.Match(s).Success)
-            {
-                return ValidationResult.Success;
-            }
-            else
-            {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
-            }
-        }
-
+        /// <inheritdoc/>
+        public override bool IsValid(object? value) => value is not string s || string.IsNullOrEmpty(s) || regex.Match(s).Success;
     }
 }

--- a/src/Tingle.Extensions.PhoneValidators/Safaricom/SafaricomPhoneNumberValidator.cs
+++ b/src/Tingle.Extensions.PhoneValidators/Safaricom/SafaricomPhoneNumberValidator.cs
@@ -16,7 +16,7 @@ namespace Tingle.Extensions.PhoneValidators.Safaricom
         // The digits are 00-09, 10-19, 20-29, 40-49, 90-99, 57-59, 68-69 when prefixed with 7 and 10-15 when prefixed with 1
         internal const string RegExComplete = @"^(?:254|\+254|0)?((?:(?:7(?:(?:[01249][0-9])|(?:5[789])|(?:6[89])))|(?:1(?:[1][0-5])))[0-9]{6})$";
 
-        private static readonly Regex regex = new Regex(@RegExComplete);
+        private static readonly Regex regex = new(@RegExComplete);
 
         /// <summary>
         /// Creates a instance of <see cref="SafaricomPhoneNumberValidator"/>

--- a/src/Tingle.Extensions.PhoneValidators/Telkom/TelkomPhoneNumberAttribute.cs
+++ b/src/Tingle.Extensions.PhoneValidators/Telkom/TelkomPhoneNumberAttribute.cs
@@ -9,39 +9,14 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class TelkomPhoneNumberAttribute : ValidationAttribute
     {
+        private static readonly Regex regex = new(TelkomPhoneNumberValidator.RegExComplete);
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SafaricomPhoneNumberAttribute"/> class.
         /// </summary>
         public TelkomPhoneNumberAttribute() : base("The field {0} must be a valid Telkom phone number.") { }
 
-        /// <summary>
-        /// Validates the specified object.
-        /// </summary>
-        /// <param name="value">The object to validate.</param>
-        /// <param name="validationContext">
-        /// The <see cref="ValidationContext"/> object that describes
-        /// the context where the validation checks are performed. This parameter cannot
-        /// be null.
-        /// </param>
-        /// <exception cref="ValidationException">Validation failed.</exception>
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-        {
-            // convert the object to a string and ensure that it is not null
-            if (!(value is string s)) return ValidationResult.Success;
-            if (string.IsNullOrEmpty(s)) return ValidationResult.Success;
-
-            // check if phone number matches RegEx
-            var regex = new Regex(TelkomPhoneNumberValidator.RegExComplete);
-            if (regex.Match(s).Success)
-            {
-                return ValidationResult.Success;
-            }
-            else
-            {
-                return new ValidationResult(errorMessage: FormatErrorMessage(name: validationContext.DisplayName),
-                                            memberNames: new string[] { validationContext.MemberName });
-            }
-        }
-
+        /// <inheritdoc/>
+        public override bool IsValid(object? value) => value is not string s || string.IsNullOrEmpty(s) || regex.Match(s).Success;
     }
 }

--- a/src/Tingle.Extensions.PhoneValidators/Telkom/TelkomPhoneNumberValidator.cs
+++ b/src/Tingle.Extensions.PhoneValidators/Telkom/TelkomPhoneNumberValidator.cs
@@ -16,7 +16,7 @@ namespace Tingle.Extensions.PhoneValidators.Telkom
         // The digits are 70-79 when prefixed with 7
         internal const string RegExComplete = @"^(?:254|\+254|0)?(7(?:(?:7[0-9]))[0-9]{6})$";
 
-        private static readonly Regex regex = new Regex(@RegExComplete);
+        private static readonly Regex regex = new(@RegExComplete);
 
         /// <summary>
         /// Creates an instance of <see cref="TelkomPhoneNumberValidator"/>

--- a/src/Tingle.Extensions.Processing/EmbeddedResourceHelper.cs
+++ b/src/Tingle.Extensions.Processing/EmbeddedResourceHelper.cs
@@ -24,13 +24,9 @@ namespace Tingle.Extensions.Processing
         /// <returns></returns>
         public static Task<string> GetResourceAsStringAsync<T>(string resourceName)
         {
-            using (var st = GetResourceAsStream<T>(resourceName))
-            {
-                using (var reader = new StreamReader(st))
-                {
-                    return reader.ReadToEndAsync();
-                }
-            }
+            using var st = GetResourceAsStream<T>(resourceName);
+            using var reader = new StreamReader(st);
+            return reader.ReadToEndAsync();
         }
 
         /// <summary>

--- a/src/Tingle.Extensions.Processing/RegexExtensions.cs
+++ b/src/Tingle.Extensions.Processing/RegexExtensions.cs
@@ -15,10 +15,17 @@
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">the input is null</exception>
         /// <exception cref="RegexMatchTimeoutException">a time-out occurred. For more information about time-outs, see the Remarks section.</exception>
-        public static bool Match(this Regex regex, string input, out Match match)
+        public static bool Match(this Regex regex, string input, out Match? match)
         {
-            match = regex.Match(input);
-            return match.Success;
+            var m = regex.Match(input);
+            if (m.Success)
+            {
+                match = m;
+                return true;
+            }
+
+            match = default;
+            return false;
         }
     }
 }

--- a/src/Tingle.Extensions.Processing/SequentialBatchProcessor.cs
+++ b/src/Tingle.Extensions.Processing/SequentialBatchProcessor.cs
@@ -20,7 +20,7 @@ namespace Tingle.Extensions.Processing
         /// </summary>
         /// <param name="concurrencyLimit">the maximum number of concurrent items</param>
         /// <param name="handler">the handler for item in the data. This handler shall be awaited.</param>
-        public SequentialBatchProcessor(int concurrencyLimit = 1, Func<T, CancellationToken, Task> handler = null)
+        public SequentialBatchProcessor(int concurrencyLimit = 1, Func<T, CancellationToken, Task>? handler = null)
         {
             concurrencyLimiter = new SemaphoreSlim(1, concurrencyLimit);
             this.handler = handler ?? ((s, c) => Task.CompletedTask);

--- a/src/Tingle.Extensions.Processing/SplitAndBatchProcessor.cs
+++ b/src/Tingle.Extensions.Processing/SplitAndBatchProcessor.cs
@@ -21,7 +21,7 @@ namespace Tingle.Extensions.Processing
         /// </summary>
         /// <param name="batchSize">the maximum number of items in a batch</param>
         /// <param name="handler">the handler for each batch of data. This handler is not be awaited, so as to ensure parallelism</param>
-        public SplitAndBatchProcessor(int batchSize = 10, Func<List<T>, CancellationToken, Task> handler = null)
+        public SplitAndBatchProcessor(int batchSize = 10, Func<List<T>, CancellationToken, Task>? handler = null)
         {
             this.batchSize = batchSize;
             this.handler = handler ?? ((s, c) => Task.CompletedTask);

--- a/tests/Tingle.Extensions.AnyOf.Tests/AnyOfTest.cs
+++ b/tests/Tingle.Extensions.AnyOf.Tests/AnyOfTest.cs
@@ -18,48 +18,33 @@ namespace Tingle.Extensions.AnyOf.Tests
         public static readonly IEnumerable<object[]> variant2TypesTestData = new List<object[]>
         {
             new object []{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string>(default(int)),
-                    WantValue = default(int),
-                    WantType = typeof(int),
-                },
+                new TestCase(new AnyOf<int, string>(default(int)),
+                             default(int),
+                             typeof(int)),
             },
 
             new object []{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string>(234),
-                    WantValue = 234,
-                    WantType = typeof(int),
-                },
+                new TestCase(new AnyOf<int, string>(234),
+                             234,
+                             typeof(int)),
             },
 
             new object []{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string>(default(string)),
-                    WantValue = default(string),
-                    WantType = typeof(string),
-                },
+                new TestCase(new AnyOf<int, string>(default(string?)),
+                             default(string?),
+                             typeof(string)),
             },
 
             new object []{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string>("Hello!"),
-                    WantValue = "Hello!",
-                    WantType = typeof(string),
-                },
+                new TestCase(new AnyOf<int, string>("Hello!"),
+                             "Hello!",
+                             typeof(string)),
             },
 
             new object []{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int?, string>(default(int?)),
-                    WantValue = default(int?),
-                    WantType = typeof(int?),
-                },
+                new TestCase(new AnyOf<int?, string>(default(int?)),
+                             default(int?),
+                             typeof(int?)),
             },
         };
 
@@ -76,67 +61,46 @@ namespace Tingle.Extensions.AnyOf.Tests
         {
 
             yield return new object[]{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string, SomeClass>(default(int)),
-                    WantValue = default(int),
-                    WantType = typeof(int),
-                },
+                new TestCase(new AnyOf<int, string, SomeClass>(default(int)),
+                             default(int),
+                             typeof(int)),
             };
 
             yield return new object[]{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string, SomeClass>(234),
-                    WantValue = 234,
-                    WantType = typeof(int),
-                },
+                new TestCase(new AnyOf<int, string, SomeClass>(234),
+                             234,
+                             typeof(int)),
             };
 
             yield return new object[]{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string, SomeClass>(default(string)),
-                    WantValue = default(string),
-                    WantType = typeof(string),
-                },
+                new TestCase(new AnyOf<int, string, SomeClass>(default(string)),
+                             default(string),
+                             typeof(string)),
             };
 
             yield return new object[]{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int, string, SomeClass>("Hello!"),
-                    WantValue = "Hello!",
-                    WantType = typeof(string),
-                },
+                new TestCase(new AnyOf<int, string, SomeClass>("Hello!"),
+                             "Hello!",
+                             typeof(string)),
             };
 
             yield return new object[]{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int?, string, SomeClass>(default(int?)),
-                    WantValue = default(int?),
-                    WantType = typeof(int?),
-                },
+                new TestCase(new AnyOf<int?, string, SomeClass>(default(int?)),
+                             default(int?),
+                             typeof(int?)),
             };
 
             yield return new object[]{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int?, string, SomeClass>(default(SomeClass)),
-                    WantValue = default(SomeClass),
-                    WantType = typeof(SomeClass),
-                },
+                new TestCase(new AnyOf<int?, string, SomeClass>(default(SomeClass)),
+                             default(SomeClass),
+                             typeof(SomeClass)),
             };
 
             var someClass = new SomeClass { SomeString = "foo" };
             yield return new object[]{
-                new TestCase
-                {
-                    AnyOf = new AnyOf<int?, string, SomeClass>(someClass),
-                    WantValue = someClass,
-                    WantType = typeof(SomeClass),
-                },
+                new TestCase(new AnyOf<int?, string, SomeClass>(someClass),
+                             someClass,
+                             typeof(SomeClass)),
             };
         }
 
@@ -153,33 +117,40 @@ namespace Tingle.Extensions.AnyOf.Tests
         {
             new object []{new Container(),},
             new object []{new Container { AnyOf2 = null },},
-            new object []{new Container { AnyOf2 = (AnyOf<int, string>)null },},
-            new object []{new Container { AnyOf2 = (string)null },},
+            new object []{new Container { AnyOf2 = null },},
+            new object []{new Container { AnyOf2 = null },},
             new object []{new Container { AnyOf3 = null },},
-            new object []{new Container { AnyOf3 = (AnyOf<int, string, SomeClass>)null },},
-            new object []{new Container { AnyOf3 = (string)null },},
-            new object []{new Container { AnyOf3 = (SomeClass)null },},
+            new object []{new Container { AnyOf3 = null },},
+            new object []{new Container { AnyOf3 = null },},
+            new object []{new Container { AnyOf3 = null },},
         };
 
         private class TestCase
         {
+            public TestCase(IAnyOf anyOf, object? wantValue, Type wantType)
+            {
+                AnyOf = anyOf ?? throw new ArgumentNullException(nameof(anyOf));
+                WantValue = wantValue;
+                WantType = wantType ?? throw new ArgumentNullException(nameof(wantType));
+            }
+
             public IAnyOf AnyOf { get; set; }
 
-            public object WantValue { get; set; }
+            public object? WantValue { get; set; }
 
             public Type WantType { get; set; }
         }
 
         private class SomeClass
         {
-            public string SomeString { get; set; }
+            public string? SomeString { get; set; }
         }
 
         private class Container
         {
-            public AnyOf<int, string> AnyOf2 { get; set; }
+            public AnyOf<int, string>? AnyOf2 { get; set; }
 
-            public AnyOf<int, string, SomeClass> AnyOf3 { get; set; }
+            public AnyOf<int, string, SomeClass>? AnyOf3 { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/AllowedValuesAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/AllowedValuesAttributeTests.cs
@@ -167,19 +167,19 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel3
         {
             [AllowedValues("blue", "green", "yellow")]
-            public string SomeValue { get; set; }
+            public string? SomeValue { get; set; }
         }
 
         class TestModel4
         {
             [AllowedValues("blue", "green", "yellow")]
-            public List<string> SomeValues { get; set; }
+            public List<string>? SomeValues { get; set; }
         }
 
         class TestModel5
         {
             [AllowedValues("blue", "green", "yellow")]
-            public List<string> SomeValues { get; set; }
+            public List<string>? SomeValues { get; set; }
         }
 
         class TestModel6
@@ -191,10 +191,10 @@ namespace Tingle.Extensions.DataAnnotations.Tests
             public float? SomeFloatValue { get; set; }
 
             [AllowedValues("blue", "green", "yellow")]
-            public string SomeStringValue { get; set; }
+            public string? SomeStringValue { get; set; }
 
             [AllowedValues("blue", "green", "yellow")]
-            public List<string> SomeStringValues { get; set; }
+            public List<string>? SomeStringValues { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/AllowedValuesAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/AllowedValuesAttributeTests.cs
@@ -29,7 +29,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
                 Assert.Equal(nameof(TestModel1.SomeValue), memeberName);
                 Assert.NotNull(val.ErrorMessage);
                 Assert.NotEmpty(val.ErrorMessage);
-                Assert.Equal($"The value(s) '{value}' is/are not allowed for field {memeberName}.", val.ErrorMessage);
+                Assert.Equal($"The field {memeberName} only permits: 1,2,3,4,5.", val.ErrorMessage);
             }
         }
 
@@ -56,7 +56,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
                 Assert.Equal(nameof(TestModel2.SomeValue), memeberName);
                 Assert.NotNull(val.ErrorMessage);
                 Assert.NotEmpty(val.ErrorMessage);
-                Assert.Equal($"The value(s) '{value}' is/are not allowed for field {memeberName}.", val.ErrorMessage);
+                Assert.Equal($"The field {memeberName} only permits: 1.1,2.2,3.3,4.4,5.5.", val.ErrorMessage);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
                 Assert.Equal(nameof(TestModel2.SomeValue), memeberName);
                 Assert.NotNull(val.ErrorMessage);
                 Assert.NotEmpty(val.ErrorMessage);
-                Assert.Equal($"The value(s) '{value}' is/are not allowed for field {memeberName}.", val.ErrorMessage);
+                Assert.Equal($"The field {memeberName} only permits: blue,green,yellow.", val.ErrorMessage);
             }
         }
 
@@ -110,17 +110,17 @@ namespace Tingle.Extensions.DataAnnotations.Tests
                 Assert.Equal(nameof(TestModel4.SomeValues), memeberName);
                 Assert.NotNull(val.ErrorMessage);
                 Assert.NotEmpty(val.ErrorMessage);
-                Assert.Equal($"The value(s) '{value}' is/are not allowed for field {memeberName}.", val.ErrorMessage);
+                Assert.Equal($"The field {memeberName} only permits: blue,green,yellow.", val.ErrorMessage);
             }
         }
 
         [Theory]
-        [InlineData(true, null, "green", "blue", "yellow")]
-        [InlineData(true, null, "blue", "yellow")]
-        [InlineData(true, null, "yellow")]
-        [InlineData(false, "yelo", "green", "blue", "yelo")]
-        [InlineData(false, "BLUE", "green", "BLUE", "yellow")]
-        public void Works_For_DoubleStringArray(bool expected, string invalid, params string[] value)
+        [InlineData(true, "green", "blue", "yellow")]
+        [InlineData(true, "blue", "yellow")]
+        [InlineData(true, "yellow")]
+        [InlineData(false, "green", "blue", "yelo")]
+        [InlineData(false, "green", "BLUE", "yellow")]
+        public void Works_For_CaseSensitiveStrings(bool expected, params string[] value)
         {
             var obj = new TestModel5 { SomeValues = value.ToList(), };
             var context = new ValidationContext(obj);
@@ -137,7 +137,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
                 Assert.Equal(nameof(TestModel5.SomeValues), memeberName);
                 Assert.NotNull(val.ErrorMessage);
                 Assert.NotEmpty(val.ErrorMessage);
-                Assert.Equal($"The value(s) '{invalid}' is/are not allowed for field {memeberName}.", val.ErrorMessage);
+                Assert.Equal($"The field {memeberName} only permits: blue,green,yellow.", val.ErrorMessage);
             }
         }
 

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/Base64AttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/Base64AttributeTests.cs
@@ -37,7 +37,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel
         {
             [Base64]
-            public string SomeKey { get; set; }
+            public string? SomeKey { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/DateMustBeInTheFutureAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/DateMustBeInTheFutureAttributeTests.cs
@@ -81,7 +81,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel3
         {
             [DateMustBeInTheFuture]
-            public string SomeField1 { get; set; }
+            public string? SomeField1 { get; set; }
 
             [DateMustBeInTheFuture]
             public int SomeField2 { get; set; }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/DateMustBeInThePastAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/DateMustBeInThePastAttributeTests.cs
@@ -81,7 +81,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel3
         {
             [DateMustBeInThePast]
-            public string SomeField1 { get; set; }
+            public string? SomeField1 { get; set; }
 
             [DateMustBeInThePast]
             public int SomeField2 { get; set; }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/KRAPinAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/KRAPinAttributeTests.cs
@@ -37,7 +37,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel
         {
             [KRAPin]
-            public string KRAPinNumber { get; set; }
+            public string? KRAPinNumber { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/Models/Child.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/Models/Child.cs
@@ -7,7 +7,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests.Models
     public class Child : IValidatableObject
     {
         [Required(ErrorMessage = "Child Parent is required")]
-        public Parent Parent { get; set; }
+        public Parent? Parent { get; set; }
 
         [Required(ErrorMessage = "Child PropertyA is required")]
         [Range(0, 10, ErrorMessage = "Child PropertyA not within range")]
@@ -17,7 +17,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests.Models
         [Range(0, 10, ErrorMessage = "Child PropertyB not within range")]
         public int? PropertyB { get; set; }
 
-        public IEnumerable<GrandChild> GrandChildren { get; set; }
+        public IEnumerable<GrandChild>? GrandChildren { get; set; }
 
         [SaveValidationContext]
         public bool HasNoRealValidation { get; set; }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/Models/ClassWithDictionary.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/Models/ClassWithDictionary.cs
@@ -4,6 +4,6 @@ namespace Tingle.Extensions.DataAnnotations.Tests.Models
 {
     public class ClassWithDictionary
     {
-        public List<Dictionary<string, Child>> Objects { get; set; }
+        public List<Dictionary<string, Child>>? Objects { get; set; }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/Models/ClassWithNullableEnumeration.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/Models/ClassWithNullableEnumeration.cs
@@ -4,6 +4,6 @@ namespace Tingle.Extensions.DataAnnotations.Tests.Models
 {
     public class ClassWithNullableEnumeration
     {
-        public List<Child> Objects { get; set; }
+        public List<Child?>? Objects { get; set; }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/Models/Parent.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/Models/Parent.cs
@@ -14,10 +14,10 @@ namespace Tingle.Extensions.DataAnnotations.Tests.Models
         [Range(0, 10, ErrorMessage = "Parent PropertyB not within range")]
         public int? PropertyB { get; set; }
 
-        public Child Child { get; set; }
+        public Child? Child { get; set; }
 
         [SkipRecursiveValidation]
-        public Child SkippedChild { get; set; }
+        public Child? SkippedChild { get; set; }
 
         [SaveValidationContext]
         public bool HasNoRealValidation { get; set; }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/Models/SaveValidationContextAttribute.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/Models/SaveValidationContextAttribute.cs
@@ -7,7 +7,8 @@ namespace Tingle.Extensions.DataAnnotations.Tests.Models
     {
         public static IList<ValidationContext> SavedContexts = new List<ValidationContext>();
 
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        /// <inheritdoc/>
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             SavedContexts.Add(validationContext);
             return ValidationResult.Success;

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/PrefixAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/PrefixAttributeTests.cs
@@ -38,7 +38,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel
         {
             [Prefix("test")]
-            public string SomeValue { get; set; }
+            public string? SomeValue { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/RecursiveValidatorTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/RecursiveValidatorTests.cs
@@ -121,7 +121,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
             };
             var validationResults = new List<ValidationResult>();
 
-            var contextItems = new Dictionary<object, object> { { "key", 12345 } };
+            var contextItems = new Dictionary<object, object?> { { "key", 12345 } };
 
             RecursiveValidator.TryValidateObjectRecursive(parent, validationResults, contextItems);
 
@@ -215,7 +215,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
             var parent = new Parent { PropertyA = 1, PropertyB = 1 };
             var classWithNullableEnumeration = new ClassWithNullableEnumeration
             {
-                Objects = new List<Child>
+                Objects = new List<Child?>
                 {
                     null,
                     new Child

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/SuffixAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/SuffixAttributeTests.cs
@@ -37,7 +37,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel
         {
             [Suffix("worLd")]
-            public string SomeValue { get; set; }
+            public string? SomeValue { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/SwiftCodeAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/SwiftCodeAttributeTests.cs
@@ -39,7 +39,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel
         {
             [SwiftCode]
-            public string TransferTo { get; set; }
+            public string? TransferTo { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.DataAnnotations.Tests/TimeZoneAttributeTests.cs
+++ b/tests/Tingle.Extensions.DataAnnotations.Tests/TimeZoneAttributeTests.cs
@@ -43,7 +43,7 @@ namespace Tingle.Extensions.DataAnnotations.Tests
         class TestModel
         {
             [TimeZone]
-            public string SomeValue { get; set; }
+            public string? SomeValue { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.Json.Tests/ObjectExtensionsTests.cs
+++ b/tests/Tingle.Extensions.Json.Tests/ObjectExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace Tingle.Extensions.Json.Tests
         public void JsonClone_Works()
         {
             var tt1 = new TestType1 { Value1 = 13, Value2 = "cake1" };
-            var tt2 = tt1.JsonClone();
+            var tt2 = tt1.JsonClone()!;
             Assert.NotEqual(tt1, tt2); // the instances mut be different
             Assert.Equal(tt1.Value1, tt2.Value1);
             Assert.Equal(tt1.Value2, tt2.Value2);
@@ -31,7 +31,7 @@ namespace Tingle.Extensions.Json.Tests
         public void JsonConvertTo_Works()
         {
             var tt2 = new TestType2 { Value1 = 13, Value2 = "cake1" };
-            var tt3 = tt2.JsonConvertTo<TestType3>();
+            var tt3 = tt2.JsonConvertTo<TestType3>()!;
             Assert.NotEqual((object)tt2, tt3);
             Assert.Equal(tt2.Value1, tt3.Value1);
             Assert.Equal(tt2.Value2, tt3.Value2);
@@ -39,7 +39,7 @@ namespace Tingle.Extensions.Json.Tests
             Assert.Null(tt2.Value3);
 
             tt3.Value3 = DateTimeOffset.UtcNow;
-            var tt2_n = tt3.JsonConvertTo<TestType2>();
+            var tt2_n = tt3.JsonConvertTo<TestType2>()!;
             Assert.NotEqual((object)tt3, tt2_n);
             Assert.Equal(tt3.Value1, tt2_n.Value1);
             Assert.Equal(tt3.Value2, tt2_n.Value2);
@@ -49,7 +49,7 @@ namespace Tingle.Extensions.Json.Tests
         class TestType1
         {
             public int Value1 { get; set; }
-            public string Value2 { get; set; }
+            public string? Value2 { get; set; }
         }
 
         class TestType2 : TestType1
@@ -60,7 +60,7 @@ namespace Tingle.Extensions.Json.Tests
         class TestType3
         {
             public int Value1 { get; set; }
-            public string Value2 { get; set; }
+            public string? Value2 { get; set; }
             public DateTimeOffset? Value3 { get; set; }
         }
     }

--- a/tests/Tingle.Extensions.Json.Tests/VersionConverterTests.cs
+++ b/tests/Tingle.Extensions.Json.Tests/VersionConverterTests.cs
@@ -27,7 +27,7 @@ namespace Tingle.Extensions.Json.Tests
 
         class TestModel
         {
-            public Version Deployed { get; set; }
+            public Version? Deployed { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.JsonPatch.Tests/AnotherDTO.cs
+++ b/tests/Tingle.Extensions.JsonPatch.Tests/AnotherDTO.cs
@@ -6,11 +6,11 @@ namespace Tingle.Extensions.JsonPatch.Tests
     {
         public int TaskNum { get; set; }
         public double Cost { get; set; }
-        public string Description { get; set; }
-        public string Status { get; set; }
+        public string? Description { get; set; }
+        public string? Status { get; set; }
         public DtoKind Kind { get; set; }
-        public List<string> Tags { get; set; }
-        public Dictionary<string, string> Metadata { get; set; }
+        public List<string>? Tags { get; set; }
+        public Dictionary<string, string>? Metadata { get; set; }
     }
 
     public enum DtoKind

--- a/tests/Tingle.Extensions.JsonPatch.Tests/JsonPropertyDTO.cs
+++ b/tests/Tingle.Extensions.JsonPatch.Tests/JsonPropertyDTO.cs
@@ -5,12 +5,12 @@ namespace Tingle.Extensions.JsonPatch.Tests
     public class JsonPropertyDTO
     {
         [JsonPropertyName("AnotherName")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 
 
     public class JsonPropertyWithAnotherNameDTO
     {
-        public string AnotherName { get; set; }
+        public string? AnotherName { get; set; }
     }
 }

--- a/tests/Tingle.Extensions.JsonPatch.Tests/JsonPropertyNameTests.cs
+++ b/tests/Tingle.Extensions.JsonPatch.Tests/JsonPropertyNameTests.cs
@@ -18,7 +18,7 @@ namespace Tingle.Extensions.JsonPatch.Tests
             var serialized = JsonSerializer.Serialize(patchDoc);
             // serialized value should have "AnotherName" as path
             // deserialize to a JsonPatchDocument<JsonPropertyWithAnotherNameDTO> to check
-            var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<JsonPropertyWithAnotherNameDTO>>(serialized);
+            var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<JsonPropertyWithAnotherNameDTO>>(serialized)!;
 
             Assert.Equal("/anothername", deserialized.Operations.First().path);
         }
@@ -49,10 +49,10 @@ namespace Tingle.Extensions.JsonPatch.Tests
             document.Replace(a => a.Description, "animals");
             document.Remove(a => a.Status);
             document.Replace(a => a.Kind, DtoKind.JustCrap);
-            document.Add(a => a.Tags, "science");
-            document.Add(a => a.Metadata, "purpose", "research");
-            document.Replace(a => a.Metadata, "purpose", "nutrition");
-            document.Remove(a => a.Metadata, "purpose");
+            document.Add(a => a.Tags!, "science");
+            document.Add(a => a.Metadata!, "purpose", "research");
+            document.Replace(a => a.Metadata!, "purpose", "nutrition");
+            document.Remove(a => a.Metadata!, "purpose");
             var actual = JsonSerializer.Serialize(document, options);
 
             // assert
@@ -81,33 +81,33 @@ namespace Tingle.Extensions.JsonPatch.Tests
             var document = JsonSerializer.Deserialize<JsonPatchDocument<AnotherDTO>>(json, options);
             Assert.NotNull(document);
 
-            var ops = document.Operations;
+            var ops = document!.Operations;
             Assert.Equal(4, ops.Count);
 
             var first = ops.FirstOrDefault();
             Assert.NotNull(first);
-            Assert.Equal("replace", first.op);
+            Assert.Equal("replace", first!.op);
             Assert.Equal(OperationType.Replace, first.OperationType);
             Assert.Equal("/description", first.path);
             //Assert.Equal("animals", first.value);
 
             var second = ops.Skip(1).FirstOrDefault();
             Assert.NotNull(second);
-            Assert.Equal("remove", second.op);
+            Assert.Equal("remove", second!.op);
             Assert.Equal(OperationType.Remove, second.OperationType);
             Assert.Equal("/status", second.path);
             Assert.Null(second.value);
 
             var third = ops.Skip(2).FirstOrDefault();
             Assert.NotNull(third);
-            Assert.Equal("replace", third.op);
+            Assert.Equal("replace", third!.op);
             Assert.Equal(OperationType.Replace, third.OperationType);
             Assert.Equal("/kind", third.path);
             //Assert.Equal("justCrap", third.value);
 
             var fourth = ops.Skip(3).FirstOrDefault();
             Assert.NotNull(fourth);
-            Assert.Equal("add", fourth.op);
+            Assert.Equal("add", fourth!.op);
             Assert.Equal(OperationType.Add, fourth.OperationType);
             Assert.Equal("/tags/-", fourth.path);
             //Assert.Equal("science", fourth.value);

--- a/tests/Tingle.Extensions.JsonPatch.Tests/SimpleDTO.cs
+++ b/tests/Tingle.Extensions.JsonPatch.Tests/SimpleDTO.cs
@@ -5,11 +5,11 @@ namespace Tingle.Extensions.JsonPatch.Tests
 {
     public class SimpleDTO
     {
-        public List<int> IntegerList { get; set; }
-        public IList<int> IntegerGenericList { get; set; }
+        public List<int>? IntegerList { get; set; }
+        public IList<int>? IntegerGenericList { get; set; }
         public int IntegerValue { get; set; }
-        public string StringProperty { get; set; }
-        public string AnotherStringProperty { get; set; }
+        public string? StringProperty { get; set; }
+        public string? AnotherStringProperty { get; set; }
         public decimal DecimalValue { get; set; }
 
         public double DoubleValue { get; set; }

--- a/tests/Tingle.Extensions.PhoneValidators.Tests/AirtelNumberValidatorTests.cs
+++ b/tests/Tingle.Extensions.PhoneValidators.Tests/AirtelNumberValidatorTests.cs
@@ -120,7 +120,7 @@ namespace Tingle.Extensions.PhoneValidators.Tests
         class TestModel
         {
             [AirtelPhoneNumber]
-            public string PhoneNumber { get; set; }
+            public string? PhoneNumber { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.PhoneValidators.Tests/E164PhoneAttributeTests.cs
+++ b/tests/Tingle.Extensions.PhoneValidators.Tests/E164PhoneAttributeTests.cs
@@ -73,13 +73,13 @@ namespace Tingle.Extensions.PhoneValidators.Tests
         class TestModel1
         {
             [E164Phone]
-            public string SomePhoneNumber { get; set; }
+            public string? SomePhoneNumber { get; set; }
         }
 
         class TestModel2
         {
             [E164Phone("KE")]
-            public string SomePhoneNumber { get; set; }
+            public string? SomePhoneNumber { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.PhoneValidators.Tests/MsisdnPhoneAttributeTests.cs
+++ b/tests/Tingle.Extensions.PhoneValidators.Tests/MsisdnPhoneAttributeTests.cs
@@ -43,7 +43,7 @@ namespace Tingle.Extensions.PhoneValidators.Tests
         class TestModel1
         {
             [MsisdnPhone]
-            public string SomePhoneNumber { get; set; }
+            public string? SomePhoneNumber { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.PhoneValidators.Tests/SafaricomNumberValidatorTests.cs
+++ b/tests/Tingle.Extensions.PhoneValidators.Tests/SafaricomNumberValidatorTests.cs
@@ -134,7 +134,7 @@ namespace Tingle.Extensions.PhoneValidators.Tests
         class TestModel
         {
             [SafaricomPhoneNumber]
-            public string PhoneNumber { get; set; }
+            public string? PhoneNumber { get; set; }
         }
     }
 }

--- a/tests/Tingle.Extensions.PhoneValidators.Tests/TelkomNumberValidatorTests.cs
+++ b/tests/Tingle.Extensions.PhoneValidators.Tests/TelkomNumberValidatorTests.cs
@@ -105,7 +105,7 @@ namespace Tingle.Extensions.PhoneValidators.Tests
         class TestModel
         {
             [TelkomPhoneNumber]
-            public string PhoneNumber { get; set; }
+            public string? PhoneNumber { get; set; }
         }
     }
 }


### PR DESCRIPTION
This PR adds support for nullable reference types and C# 9 syntax to the repository. In the process of changing all the projects, other changes were made:

- validation attributes now override the simpler `IdValid(object? value)` which returns bools and is easier to maintain.
- the error message for `AllowedValuesAttribute` was updated to not include the unsupported values but instead include the allowed values.