### PR TITLE
Use .NET6 TimeZoneInfo functionality

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,10 +41,10 @@ jobs:
       with:
         useConfigFile: true
 
-    - name: Setup .NET 5.0 SDK
+    - name: Setup .NET 6 SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.x'
         source-url: https://api.nuget.org/v3/index.json
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}

--- a/src/Tingle.Extensions.DataAnnotations/TimeZoneAttribute.cs
+++ b/src/Tingle.Extensions.DataAnnotations/TimeZoneAttribute.cs
@@ -1,4 +1,6 @@
-﻿using TimeZoneConverter;
+﻿#if !NET6_0_OR_GREATER
+using TimeZoneConverter;
+#endif
 
 namespace System.ComponentModel.DataAnnotations
 {
@@ -17,7 +19,18 @@ namespace System.ComponentModel.DataAnnotations
         /// <inheritdoc/>
         public override bool IsValid(object? value)
         {
-            return value is not string s || string.IsNullOrEmpty(s) || TZConvert.TryGetTimeZoneInfo(windowsOrIanaTimeZoneId: s, out _);
+            if (value is not string s || string.IsNullOrEmpty(s)) return true;
+
+#if NET6_0_OR_GREATER
+            try
+            {
+                _ = TimeZoneInfo.FindSystemTimeZoneById(s);
+                return true;
+            }
+            catch (TimeZoneNotFoundException) { return false; }
+#else
+            return TZConvert.TryGetTimeZoneInfo(windowsOrIanaTimeZoneId: s, out _);
+#endif
         }
     }
 }

--- a/src/Tingle.Extensions.DataAnnotations/Tingle.Extensions.DataAnnotations.csproj
+++ b/src/Tingle.Extensions.DataAnnotations/Tingle.Extensions.DataAnnotations.csproj
@@ -11,6 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Use the inbuilt `TimeZoneInfo` functionality in .NET 6 that supports IANA hence only install `TimeZoneConverter` library in older targets.