### PR TITLE
Mongo cache verification

### DIFF
--- a/src/Tingle.Extensions.Caching.MongoDB/MongoCache.cs
+++ b/src/Tingle.Extensions.Caching.MongoDB/MongoCache.cs
@@ -353,7 +353,7 @@ public class MongoCache : IDistributedCache, IDisposable
                 var collection = database.GetCollection<MongoCacheEntry>(options.CollectionName);
 
                 var keys = Builders<MongoCacheEntry>.IndexKeys.Ascending(x => x.ExpiresAt);
-                var ci_opt = new CreateIndexOptions
+                var ci_opt = new CreateIndexOptions<MongoCacheEntry>
                 {
                     Name = "DefaultExpireAfterSecondsIndex",
                     ExpireAfter = TimeSpan.Zero, // expire/remove immediately
@@ -382,7 +382,7 @@ public class MongoCache : IDistributedCache, IDisposable
                 var collection = database.GetCollection<MongoCacheEntry>(options.CollectionName);
 
                 var keys = Builders<MongoCacheEntry>.IndexKeys.Ascending(x => x.ExpiresAt);
-                var ci_opt = new CreateIndexOptions
+                var ci_opt = new CreateIndexOptions<MongoCacheEntry>
                 {
                     Name = "DefaultExpireAfterSecondsIndex",
                     ExpireAfter = TimeSpan.Zero, // expire/remove immediately

--- a/src/Tingle.Extensions.Caching.MongoDB/MongoCache.cs
+++ b/src/Tingle.Extensions.Caching.MongoDB/MongoCache.cs
@@ -368,6 +368,7 @@ public class MongoCache : IDistributedCache, IDisposable
 
     private IMongoCollection<MongoCacheEntry> MongoCollectionInitialize()
     {
+        initializedClient = options.MongoClient == null;
         client = GetClientInstance();
 
         var database = client.GetDatabase(options.DatabaseName);


### PR DESCRIPTION
This PR cleans up a few things in the `IDistributedCache` implementation for MongoDB but most importantly validates that an existing collection is used. This will hopefully clear the air on #126