### PR TITLE
Configurable renewal threshold for OAuthClientCredentialHandler

### DIFF
--- a/src/Tingle.Extensions.Http.Authentication/CachingAuthenticationHeaderHandler.cs
+++ b/src/Tingle.Extensions.Http.Authentication/CachingAuthenticationHeaderHandler.cs
@@ -43,7 +43,7 @@ public abstract class CachingAuthenticationHeaderHandler : AuthenticationHeaderH
     /// </summary>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    protected async Task<string?> GetTokenFromCacheAsync(CancellationToken cancellationToken)
+    protected virtual async Task<string?> GetTokenFromCacheAsync(CancellationToken cancellationToken)
     {
         if (TryGetCache(out var cache, out var key))
         {
@@ -65,7 +65,7 @@ public abstract class CachingAuthenticationHeaderHandler : AuthenticationHeaderH
     /// <param name="expiresOn"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    protected async Task SetTokenInCacheAsync(string value, DateTimeOffset expiresOn, CancellationToken cancellationToken)
+    protected virtual async Task SetTokenInCacheAsync(string value, DateTimeOffset expiresOn, CancellationToken cancellationToken)
     {
         if (TryGetCache(out var cache, out var key))
         {

--- a/src/Tingle.Extensions.Http.Authentication/OAuthClientCredentialHandler.cs
+++ b/src/Tingle.Extensions.Http.Authentication/OAuthClientCredentialHandler.cs
@@ -50,6 +50,12 @@ public class OAuthClientCredentialHandler : CachingAuthenticationHeaderHandler
     /// </summary>
     public virtual string? Resource { get; set; }
 
+    /// <summary>
+    /// The duration of before expiry of the token that it should be renewed.
+    /// Defaults to 10 seconds; minumum 5 seconds.
+    /// </summary>
+    public virtual TimeSpan RenewalThreshold { get; set; } = TimeSpan.FromSeconds(5);
+
     /// <inheritdoc/>
     protected override async Task<string?> GetParameterAsync(HttpRequestMessage request,
                                                              CancellationToken cancellationToken)
@@ -82,8 +88,9 @@ public class OAuthClientCredentialHandler : CachingAuthenticationHeaderHandler
             // bring the expiry time 5 seconds earlier to allow time for renewal
             if (expires is not null)
             {
-                var ex = expires.Value;
-                ex -= TimeSpan.FromSeconds(5);
+                var threshold = Math.Abs(RenewalThreshold.Ticks);
+                threshold = Math.Max(TimeSpan.FromSeconds(5).Ticks, threshold); // minimum of seconds
+                var ex = expires.Value - TimeSpan.FromTicks(threshold);
                 await SetTokenInCacheAsync(token, ex, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Tingle.Extensions.Http.Authentication/Tingle.Extensions.Http.Authentication.csproj
+++ b/src/Tingle.Extensions.Http.Authentication/Tingle.Extensions.Http.Authentication.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Tingle.Extensions.Http.Authentication.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AnyOf" Version="0.3.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />


### PR DESCRIPTION
Made renewal threshold for `OAuthClientCredentialHandler` configurable with the default as 10 seconds and a minimum of 5 seconds.

`GetTokenFromCacheAsync(...)` and `SetTokenInCacheAsync(...)` are also marked as virtual in case one wants to override the behaviour.