### PR TITLE
Remove SourceLink package

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,7 +42,6 @@
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="Polyfill " Version="1.32.1" PrivateAssets="All"/>
   </ItemGroup>
 


### PR DESCRIPTION
This is redundant now as it's built in to the .NET 8 SDK.