### PR TITLE
Resolving `TelemetryClient` in `ActivitySourceDependencyCollector` should be on need

### DIFF
--- a/src/Tingle.AspNetCore.ApplicationInsights/IServiceCollectionExtensions.cs
+++ b/src/Tingle.AspNetCore.ApplicationInsights/IServiceCollectionExtensions.cs
@@ -62,6 +62,6 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection AddActivitySourceDependencyCollector(this IServiceCollection services,
                                                                           IDictionary<string, ActivitySamplingResult> activities)
     {
-        return services.AddHostedService(p => ActivatorUtilities.CreateInstance<ActivitySourceDependencyCollector>(p, [activities]));
+        return services.AddHostedService(p => new ActivitySourceDependencyCollector(p, activities));
     }
 }


### PR DESCRIPTION
`IHostedService` implementations may be invoked before the `TelemetryClient` is available. This change makes it possible to use `ActivitySourceDependencyCollector` in such scenarios instead of crashing.