### PR TITLE
Implement `IParsable<T>`

### DIFF
--- a/src/Tingle.Extensions.MongoDB/Serialization/Serializers/EtagBsonSerializer.cs
+++ b/src/Tingle.Extensions.MongoDB/Serialization/Serializers/EtagBsonSerializer.cs
@@ -56,7 +56,7 @@ public class EtagBsonSerializer : StructSerializerBase<Etag>, IRepresentationCon
         var bsonType = context.Reader.CurrentBsonType;
         return bsonType switch
         {
-            BsonType.String => new Etag(_stringSerializer.Deserialize(context)),
+            BsonType.String => Etag.Parse(_stringSerializer.Deserialize(context)),
             BsonType.Int64 => new Etag((ulong)_int64Serializer.Deserialize(context)),
             BsonType.Binary => new Etag(_byteArraySerializer.Deserialize(context)),
             _ => throw CreateCannotDeserializeFromBsonTypeException(bsonType),

--- a/src/Tingle.Extensions.Primitives/Converters/EtagJsonConverter.cs
+++ b/src/Tingle.Extensions.Primitives/Converters/EtagJsonConverter.cs
@@ -33,7 +33,7 @@ public class EtagJsonConverter : JsonConverter<Etag>
         }
 
         var str = reader.GetString();
-        return new Etag(str!);
+        return Etag.Parse(str!);
     }
 
     /// <inheritdoc/>

--- a/src/Tingle.Extensions.Primitives/Extensions/NumberAbbreviationExtensions.cs
+++ b/src/Tingle.Extensions.Primitives/Extensions/NumberAbbreviationExtensions.cs
@@ -24,15 +24,15 @@ public static class NumberAbbreviationExtensions
     /// using the specified culture-specific format information.
     /// </summary>
     /// <param name="source">the numeric value</param>
-    /// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
     /// <returns>The string representation of the value of this instance as specified by format and provider.</returns>
     /// <exception cref="FormatException">format is invalid or not supported.</exception>
-    public static string ToStringAbbreviated(this long source, IFormatProvider formatProvider)
+    public static string ToStringAbbreviated(this long source, IFormatProvider? provider)
     {
-        if (source > 999999999 || source < -999999999) return source.ToString(FormatBillions, formatProvider);
-        else if (source > 999999 || source < -999999) return source.ToString(FormatMillions, formatProvider);
-        else if (source > 999 || source < -999) return source.ToString(FormatKilo, formatProvider);
-        return source.ToString(formatProvider);
+        if (source > 999999999 || source < -999999999) return source.ToString(FormatBillions, provider);
+        else if (source > 999999 || source < -999999) return source.ToString(FormatMillions, provider);
+        else if (source > 999 || source < -999) return source.ToString(FormatKilo, provider);
+        return source.ToString(provider);
     }
 
     /// <summary>
@@ -48,14 +48,14 @@ public static class NumberAbbreviationExtensions
     /// using the specified culture-specific format information.
     /// </summary>
     /// <param name="source">the numeric value</param>
-    /// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
     /// <returns>The string representation of the value of this instance as specified by format and provider.</returns>
     /// <exception cref="FormatException">format is invalid or not supported.</exception>
-    public static string ToStringAbbreviated(this int source, IFormatProvider formatProvider)
+    public static string ToStringAbbreviated(this int source, IFormatProvider? provider)
     {
-        if (source > 999999999 || source < -999999999) return source.ToString(FormatBillions, formatProvider);
-        else if (source > 999999 || source < -999999) return source.ToString(FormatMillions, formatProvider);
-        else if (source > 999 || source < -999) return source.ToString(FormatKilo, formatProvider);
-        return source.ToString(formatProvider);
+        if (source > 999999999 || source < -999999999) return source.ToString(FormatBillions, provider);
+        else if (source > 999999 || source < -999999) return source.ToString(FormatMillions, provider);
+        else if (source > 999 || source < -999) return source.ToString(FormatKilo, provider);
+        return source.ToString(provider);
     }
 }

--- a/src/Tingle.Extensions.Primitives/SequenceNumber.cs
+++ b/src/Tingle.Extensions.Primitives/SequenceNumber.cs
@@ -100,7 +100,7 @@ public readonly struct SequenceNumber : IComparable<SequenceNumber>, IEquatable<
     public override string ToString() => value.ToString();
 
     /// <inheritdoc/>
-    public string ToString(string? format, IFormatProvider? formatProvider) => value.ToString(format, formatProvider);
+    public string ToString(string? format, IFormatProvider? provider) => value.ToString(format, provider);
 
     /// <inheritdoc/>
     public int CompareTo(SequenceNumber other) => value.CompareTo(other.value);

--- a/src/Tingle.Extensions.Primitives/SwiftCode.cs
+++ b/src/Tingle.Extensions.Primitives/SwiftCode.cs
@@ -16,7 +16,7 @@ namespace Tingle.Extensions.Primitives;
 /// <param name="branch"></param>
 [JsonConverter(typeof(SwiftCodeJsonConverter))]
 [TypeConverter(typeof(SwiftCodeTypeConverter))]
-public sealed partial class SwiftCode(string institution, string country, string location, string? branch = null) : IEquatable<SwiftCode>, IComparable<SwiftCode>, IConvertible
+public sealed partial class SwiftCode(string institution, string country, string location, string? branch = null) : IEquatable<SwiftCode>, IComparable<SwiftCode>, IConvertible, IParsable<SwiftCode>
 {
     /// <summary>
     /// A 4-letter representation of the institution.
@@ -122,16 +122,42 @@ public sealed partial class SwiftCode(string institution, string country, string
     /// </code>
     /// The default expression used for validation is <c>^([a-zA-Z]{4})([a-zA-Z]{2})([a-zA-Z0-9]{2})([a-zA-Z0-9]{3})?$</c>
     /// </summary>
-    /// <param name="code">the string representation of a swift code as specified under ISO-9362.</param>
+    /// <param name="s">the string representation of a swift code as specified under ISO-9362.</param>
     /// <returns></returns>
-    /// <exception cref="ArgumentNullException"><paramref name="code"/> is null.</exception>
-    /// <exception cref="FormatException"><paramref name="code"/> does not have a valid format.</exception>
-    public static SwiftCode Parse(string code)
-    {
-        ArgumentNullException.ThrowIfNull(code);
+    /// <exception cref="ArgumentNullException"><paramref name="s"/> is null.</exception>
+    /// <exception cref="FormatException"><paramref name="s"/> does not have a valid format.</exception>
+    public static SwiftCode Parse(string s) => Parse(s, null);
 
-        if (TryParse(code, out var result)) return result;
-        throw new FormatException($"'{code}' is not a valid Swift code.");
+    /// <summary>
+    /// Parses a code into <see cref="SwiftCode"/>. The format of a Swift Code is as specified under ISO-9362.
+    /// The Swift code can be either 8 or 11 characters long, an 8 digits code implies the primary office.
+    /// The code consists of 4 separate section, and the format arrange in the following manner: <c>AAAA BB CC DDD</c>.
+    /// <code>The first 4 characters ("AAAA") specify the institution. Only letters.</code>
+    /// <code>
+    /// The next 2 characters("BB") specify the country where the institution's located. The code follows the format
+    /// of ISO 3166-1 alpha-2 country code. Only letters.
+    /// </code>
+    /// <code>
+    /// The next 2 characters ("CC") specify the institution's location. Can be letters and digits.
+    /// Passive participants will have "1" in the second character.
+    /// </code>
+    /// <code>
+    /// The last 3 characters("DDD") specify the institution's branch. This section is an optional.
+    /// When set to 'XXX' refers to a primary office. Can be letters and digits.
+    /// </code>
+    /// The default expression used for validation is <c>^([a-zA-Z]{4})([a-zA-Z]{2})([a-zA-Z0-9]{2})([a-zA-Z0-9]{3})?$</c>
+    /// </summary>
+    /// <param name="s">the string representation of a swift code as specified under ISO-9362.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information about <paramref name="s"/>.</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="s"/> is null.</exception>
+    /// <exception cref="FormatException"><paramref name="s"/> does not have a valid format.</exception>
+    public static SwiftCode Parse(string s, IFormatProvider? provider)
+    {
+        ArgumentNullException.ThrowIfNull(s);
+
+        if (TryParse(s, provider, out var result)) return result;
+        throw new FormatException($"'{s}' is not a valid Swift code.");
     }
 
     /// <summary>
@@ -153,19 +179,52 @@ public sealed partial class SwiftCode(string institution, string country, string
     /// </code>
     /// The default expression used for validation is <c>^([a-zA-Z]{4})([a-zA-Z]{2})([a-zA-Z0-9]{2})([a-zA-Z0-9]{3})?$</c>
     /// </summary>
-    /// <param name="code">the string representation of a swift code as specified under ISO-9362.</param>
+    /// <param name="s">the string representation of a swift code as specified under ISO-9362.</param>
     /// <param name="value">
     /// When this method returns, contains the value associated parsed,
     /// if successful; otherwise, <see langword="null"/> is returned.
     /// This parameter is passed uninitialized.
     /// </param>
     /// <returns>
-    /// <see langword="true"/> if <paramref name="code"/> could be parsed; otherwise, false.
+    /// <see langword="true"/> if <paramref name="s"/> could be parsed; otherwise, false.
     /// </returns>
-    public static bool TryParse(string code, [NotNullWhen(true)] out SwiftCode? value)
+    public static bool TryParse(string? s, [MaybeNullWhen(false)] out SwiftCode value) => TryParse(s, null, out value);
+
+    /// <summary>
+    /// Parses a code into <see cref="SwiftCode"/>. The format of a Swift Code is as specified under ISO-9362.
+    /// The Swift code can be either 8 or 11 characters long, an 8 digits code implies the primary office.
+    /// The code consists of 4 separate section, and the format arrange in the following manner: <c>AAAA BB CC DDD</c>.
+    /// <code>The first 4 characters ("AAAA") specify the institution. Only letters.</code>
+    /// <code>
+    /// The next 2 characters("BB") specify the country where the institution's located. The code follows the format
+    /// of ISO 3166-1 alpha-2 country code. Only letters.
+    /// </code>
+    /// <code>
+    /// The next 2 characters ("CC") specify the institution's location. Can be letters and digits.
+    /// Passive participants will have "1" in the second character.
+    /// </code>
+    /// <code>
+    /// The last 3 characters("DDD") specify the institution's branch. This section is an optional.
+    /// When set to 'XXX' refers to a primary office. Can be letters and digits.
+    /// </code>
+    /// The default expression used for validation is <c>^([a-zA-Z]{4})([a-zA-Z]{2})([a-zA-Z0-9]{2})([a-zA-Z0-9]{3})?$</c>
+    /// </summary>
+    /// <param name="s">the string representation of a swift code as specified under ISO-9362.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information about <paramref name="s"/>.</param>
+    /// <param name="value">
+    /// When this method returns, contains the value associated parsed,
+    /// if successful; otherwise, <see langword="null"/> is returned.
+    /// This parameter is passed uninitialized.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="s"/> could be parsed; otherwise, false.
+    /// </returns>
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out SwiftCode value)
     {
-        value = null;
-        var match = GetPattern().Match(code);
+        value = default;
+        if (string.IsNullOrWhiteSpace(s)) return false;
+
+        var match = GetPattern().Match(s);
         if (!match.Success) return false;
 
         value = new SwiftCode(institution: match.Groups[1].Value,
@@ -183,8 +242,8 @@ public sealed partial class SwiftCode(string institution, string country, string
     public static bool operator !=(SwiftCode left, SwiftCode right) => !(left == right);
 
     /// <summary>Converts a string to a <see cref="SwiftCode"/>.</summary>
-    /// <param name="code">the string representation of the code</param>
-    public static implicit operator SwiftCode(string code) => Parse(code: code);
+    /// <param name="s">the string representation of the code</param>
+    public static implicit operator SwiftCode(string s) => Parse(s);
 
     /// <summary>Converts a <see cref="SwiftCode"/> to a string.</summary>
     /// <param name="code">the string representation of the code</param>

--- a/tests/Tingle.Extensions.Primitives.Tests/EtagTests.cs
+++ b/tests/Tingle.Extensions.Primitives.Tests/EtagTests.cs
@@ -12,7 +12,7 @@ public class EtagTests
     [InlineData("CgAAAAAAAAA=", "CwAAAAAAAAA=")]
     public void Next_Works(string current, string expected)
     {
-        var etag = new Etag(current);
+        var etag = Etag.Parse(current);
         var actual = etag.Next().ToString();
         Assert.Equal(expected, actual);
     }
@@ -36,9 +36,9 @@ public class EtagTests
     [InlineData(new string[] { "DAAAAAAAAAA=", "CAAAAAAAAAA=", "AQAAAAAAAAA=", "FQAAAAAAAAA=", }, "KgAAAAAAAAA=")]
     public void Combine_Works_ForStrings(string[] values, string expected)
     {
-        var tags = values.Select(u => (Etag)u).ToArray();
+        var tags = values.Select(v => Etag.Parse(v)).ToArray();
         var actual = Etag.Combine(tags);
-        Assert.Equal((Etag)expected, actual);
+        Assert.Equal(Etag.Parse(expected), actual);
     }
 
     [Theory]
@@ -93,7 +93,7 @@ public class EtagTests
     [InlineData("AQAAAAAAAAA=", "AQAAAAAAAAA=")]
     public void CreateFromString_Works(string value, string expected)
     {
-        var etag = new Etag(value);
+        var etag = Etag.Parse(value);
         var actual = etag.ToString();
         Assert.Equal(expected, actual);
     }

--- a/tests/Tingle.Extensions.Primitives.Tests/MoneyTests.cs
+++ b/tests/Tingle.Extensions.Primitives.Tests/MoneyTests.cs
@@ -140,13 +140,6 @@ public class MoneyTests
         Assert.Equal(new Money("JPY", 765), yen);
     }
 
-    [Fact, UseCulture("en-US")]
-    public void Parse_Works_DollarSymbolInUSA()
-    {
-        var dollar = Money.Parse("$765.43");
-        Assert.Equal(new Money("USD", 76543), dollar);
-    }
-
     [Fact, UseCulture("nl-NL")]
     public void Parsing_DollarSymbolInNetherlands_Fails()
     {


### PR DESCRIPTION
`IParsable<T>` is useful for generic parsing. This PR adds support for it on `ByteSize`, `Duration`, `Etag`, `Ksuid`, `Money`, and `SwiftCode`.

Consequently:
1. Creating `Etag` from string has been marked as obsolete in favour of parsing.
2. Parsing of `Money` requires more explict currency specification where the symbol is used by multiple currencies, such as `$` which is used by 9 currencies. `Money.Parse(...)` will throw but `Money.TryParse(...)` will return false.