### PR TITLE
Drop net6 and net7 which are EoL

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <!--<IsPackable>true</IsPackable>-->
     <Authors>Tingle Software</Authors>
     <Company>Tingle Software</Company>
-    <IsAotCompatible>true</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
@@ -29,11 +29,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('Tingle.AspNetCore.'))">
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('Tingle.Extensions.'))">
-    <TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tingle.AspNetCore.ApplicationInsights/Tingle.AspNetCore.ApplicationInsights.csproj
+++ b/src/Tingle.AspNetCore.ApplicationInsights/Tingle.AspNetCore.ApplicationInsights.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Description>Convenience functionality for Application Insights on AspNetCore</Description>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tingle.AspNetCore.JsonPatch.NewtonsoftJson/Tingle.AspNetCore.JsonPatch.NewtonsoftJson.csproj
+++ b/src/Tingle.AspNetCore.JsonPatch.NewtonsoftJson/Tingle.AspNetCore.JsonPatch.NewtonsoftJson.csproj
@@ -9,9 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/Tingle.Extensions.DataAnnotations/RecursiveValidator.cs
+++ b/src/Tingle.Extensions.DataAnnotations/RecursiveValidator.cs
@@ -200,6 +200,7 @@ public static class RecursiveValidator
 }
 internal static class ObjectExtensions
 {
+    [RequiresUnreferencedCode("The Type of instance cannot be statically discovered.")]
     public static object GetPropertyValue(this object o, string propertyName)
     {
         var propertyInfo = o.GetType().GetProperty(propertyName);

--- a/src/Tingle.Extensions.EntityFrameworkCore/Tingle.Extensions.EntityFrameworkCore.csproj
+++ b/src/Tingle.Extensions.EntityFrameworkCore/Tingle.Extensions.EntityFrameworkCore.csproj
@@ -2,17 +2,12 @@
 
   <PropertyGroup>
     <Description>Convenience functionality and extensions for working with EntityFrameworkCore</Description>
-    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageTags>$(PackageTags);EntityFrameworkCore;efcore</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />

--- a/src/Tingle.Extensions.JsonPatch/Tingle.Extensions.JsonPatch.csproj
+++ b/src/Tingle.Extensions.JsonPatch/Tingle.Extensions.JsonPatch.csproj
@@ -21,6 +21,7 @@
       Have a look at the project site for the current status of this package and to learn how to get started.
     </Description>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tingle.Extensions.MongoDB/Tingle.Extensions.MongoDB.csproj
+++ b/src/Tingle.Extensions.MongoDB/Tingle.Extensions.MongoDB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Extensions for working with MongoDB</Description>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tingle.Extensions.Mustache/Tingle.Extensions.Mustache.csproj
+++ b/src/Tingle.Extensions.Mustache/Tingle.Extensions.Mustache.csproj
@@ -5,7 +5,7 @@
 This project is built on the good work offered in Wildbit's implementation at https://github.com/ActiveCampaign/mustachio
 For more information on the spec, refer to https://mustache.github.io/
     </Description>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tingle.Extensions.Primitives/Tingle.Extensions.Primitives.csproj
+++ b/src/Tingle.Extensions.Primitives/Tingle.Extensions.Primitives.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Additional primitive types such as Money, Currency, Country, Duration, Keygen, Etag, Ksuid, Language, SequenceNumber, ByteSize, etc</Description>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tingle.Extensions.PushNotifications/IServiceCollectionExtensions.cs
+++ b/src/Tingle.Extensions.PushNotifications/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Tingle.Extensions.Http;
+﻿using System.Diagnostics.CodeAnalysis;
+using Tingle.Extensions.Http;
 using Tingle.Extensions.PushNotifications;
 using Tingle.Extensions.PushNotifications.Apple;
 using Tingle.Extensions.PushNotifications.FcmLegacy;
@@ -68,7 +69,9 @@ public static class IServiceCollectionExtensions
         return builder;
     }
 
-    private static IHttpClientBuilder AddNotifier<TNotifier, TOptions>(this IServiceCollection services, Action<TOptions>? configure = null)
+    private static IHttpClientBuilder AddNotifier<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNotifier, TOptions>(
+        this IServiceCollection services,
+        Action<TOptions>? configure = null)
 
         where TNotifier : AbstractHttpApiClient<TOptions>
         where TOptions : AbstractHttpApiClientOptions, new()

--- a/src/Tingle.Extensions.PushNotifications/Tingle.Extensions.PushNotifications.csproj
+++ b/src/Tingle.Extensions.PushNotifications/Tingle.Extensions.PushNotifications.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Clients for sending push notifications via FCM, APNS etc</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
.NET 6 reached the end of life on November 12, 2024 while .NET 7 reached the end of life on May 14, 2024. This PR removes support for them and adds support for .NET 9 was added.

Consequently, `Tingle.Extensions.JsonPatch` no longer supports trimming. This an uncaught error in the past.