### PR TITLE
No longer pack/publish packages that are no longer maintained

### DIFF
--- a/src/Tingle.AspNetCore.ApplicationInsights/Tingle.AspNetCore.ApplicationInsights.csproj
+++ b/src/Tingle.AspNetCore.ApplicationInsights/Tingle.AspNetCore.ApplicationInsights.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <Description>Convenience functionality for Application Insights on AspNetCore</Description>
+    <!-- No longer maintained, this is just for reference -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tingle.Extensions.Serilog/Tingle.Extensions.Serilog.csproj
+++ b/src/Tingle.Extensions.Serilog/Tingle.Extensions.Serilog.csproj
@@ -5,6 +5,8 @@
 Extensions for working with Serilog.
 Including easier registration when working with different host setups, and general basics.
 </Description>
+    <!-- No longer maintained, this is just for reference -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
`Tingle.AspNetCore.ApplicationInsights` and `Tingle.Extensions.Serilog` are no longer maintained, so we do not need more releases.