### PR TITLE
Reduce disabling of warnings hence improve AoT compatibility

### DIFF
--- a/src/Tingle.AspNetCore.Tokens/Extensions/ControllerExtensions.cs
+++ b/src/Tingle.AspNetCore.Tokens/Extensions/ControllerExtensions.cs
@@ -91,6 +91,8 @@ public static class ControllerExtensions
     /// <param name="token">the token containing the value</param>
     /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
     /// <param name="headerName">the name of the header to write the protected token</param>
+    [RequiresUnreferencedCode(MessageStrings.SerializationUnreferencedCodeMessage)]
+    [RequiresDynamicCode(MessageStrings.SerializationRequiresDynamicCodeMessage)]
     public static ContinuationTokenResult<T> Ok<T>(this ControllerBase controller,
                                                    [ActionResultObjectValue] object value,
                                                    ContinuationToken<T> token,
@@ -109,6 +111,8 @@ public static class ControllerExtensions
     /// <param name="tokenValue">the token's value</param>
     /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
     /// <param name="headerName">the name of the header to write the protected token</param>
+    [RequiresUnreferencedCode(MessageStrings.SerializationUnreferencedCodeMessage)]
+    [RequiresDynamicCode(MessageStrings.SerializationRequiresDynamicCodeMessage)]
     public static ContinuationTokenResult<T> Ok<T>(this ControllerBase controller,
                                                    [ActionResultObjectValue] object value,
                                                    T tokenValue,
@@ -133,6 +137,8 @@ public static class ControllerExtensions
     /// <param name="expiration"></param>
     /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
     /// <param name="headerName">the name of the header to write the protected token</param>
+    [RequiresUnreferencedCode(MessageStrings.SerializationUnreferencedCodeMessage)]
+    [RequiresDynamicCode(MessageStrings.SerializationRequiresDynamicCodeMessage)]
     public static ContinuationTokenResult<T> Ok<T>(this ControllerBase controller,
                                                    [ActionResultObjectValue] object value,
                                                    T tokenValue,

--- a/src/Tingle.AspNetCore.Tokens/Mvc/ContinuationTokenResult.cs
+++ b/src/Tingle.AspNetCore.Tokens/Mvc/ContinuationTokenResult.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Mvc;
 /// An <see cref="OkObjectResult"/> that supports writing the continuation token to a header before writing the response body
 /// </summary>
 /// <typeparam name="T">The type of data contained</typeparam>
+[RequiresUnreferencedCode(MessageStrings.SerializationUnreferencedCodeMessage)]
+[RequiresDynamicCode(MessageStrings.SerializationRequiresDynamicCodeMessage)]
 public class ContinuationTokenResult<T> : OkObjectResult
 {
     private readonly ContinuationToken<T> token;
@@ -23,8 +25,6 @@ public class ContinuationTokenResult<T> : OkObjectResult
     /// <param name="token">the token containing the value</param>
     /// <param name="serializerOptions">Options to control the behavior during parsing.</param>
     /// <param name="headerName">the name of the header to write the protected token</param>
-    [RequiresUnreferencedCode(MessageStrings.SerializationUnreferencedCodeMessage)]
-    [RequiresDynamicCode(MessageStrings.SerializationRequiresDynamicCodeMessage)]
     public ContinuationTokenResult([ActionResultObjectValue] object value,
                                    ContinuationToken<T> token,
                                    JsonSerializerOptions? serializerOptions = null,
@@ -63,8 +63,6 @@ public class ContinuationTokenResult<T> : OkObjectResult
             // get an instance of the protector
             var protector = context.HttpContext.RequestServices.GetRequiredService<ITokenProtector<T>>();
 
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-#pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
             // generate a new protected value based on the type of token
             string protected_val;
             var value = token.GetValue();
@@ -86,7 +84,5 @@ public class ContinuationTokenResult<T> : OkObjectResult
             if (!string.IsNullOrWhiteSpace(protected_val))
                 context.HttpContext.Response.Headers[headerName] = protected_val;
         }
-#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
     }
 }

--- a/src/Tingle.Extensions.EntityFrameworkCore/Converters/JsonNodeConverter.cs
+++ b/src/Tingle.Extensions.EntityFrameworkCore/Converters/JsonNodeConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
 #pragma warning disable CS8603 // Possible null reference return.
@@ -17,6 +18,8 @@ public class JsonNodeConverter : ValueConverter<JsonNode, string>
 }
 
 ///
+[RequiresDynamicCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
+[RequiresUnreferencedCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
 public class JsonNodeComparer : ValueComparer<JsonNode>
 {
     ///

--- a/src/Tingle.Extensions.EntityFrameworkCore/Converters/JsonObjectConverter.cs
+++ b/src/Tingle.Extensions.EntityFrameworkCore/Converters/JsonObjectConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
 #pragma warning disable CS8603 // Possible null reference return.
@@ -17,6 +18,8 @@ public class JsonObjectConverter : ValueConverter<JsonObject, string>
 }
 
 ///
+[RequiresDynamicCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
+[RequiresUnreferencedCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
 public class JsonObjectComparer : ValueComparer<JsonObject>
 {
     ///

--- a/src/Tingle.Extensions.EntityFrameworkCore/Extensions/PropertyBuilderExtensions.cs
+++ b/src/Tingle.Extensions.EntityFrameworkCore/Extensions/PropertyBuilderExtensions.cs
@@ -174,6 +174,8 @@ public static class PropertyBuilderExtensions
     /// </summary>
     /// <param name="propertyBuilder">The <see cref="PropertyBuilder{TProperty}"/> to extend.</param>
     /// <returns></returns>
+    [RequiresDynamicCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
+    [RequiresUnreferencedCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
     public static PropertyBuilder<JsonObject> HasJsonObjectConversion(this PropertyBuilder<JsonObject> propertyBuilder)
     {
         ArgumentNullException.ThrowIfNull(propertyBuilder);
@@ -189,6 +191,8 @@ public static class PropertyBuilderExtensions
     /// </summary>
     /// <param name="propertyBuilder">The <see cref="PropertyBuilder{TProperty}"/> to extend.</param>
     /// <returns></returns>
+    [RequiresDynamicCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
+    [RequiresUnreferencedCode(MessageStrings.JsonComparisonRequiresDynamicCodeMessage)]
     public static PropertyBuilder<JsonNode> HasJsonNodeConversion(this PropertyBuilder<JsonNode> propertyBuilder)
     {
         ArgumentNullException.ThrowIfNull(propertyBuilder);

--- a/src/Tingle.Extensions.EntityFrameworkCore/MessageStrings.cs
+++ b/src/Tingle.Extensions.EntityFrameworkCore/MessageStrings.cs
@@ -6,4 +6,5 @@ internal class MessageStrings
     public const string SerializationRequiresDynamicCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.";
 
     public const string MigrationsRequiresDynamicCodeMessage = "Migration operations are not supported with Native AOT. Use a migration bundle or an alternate way of executing migration operations.";
+    public const string JsonComparisonRequiresDynamicCodeMessage = "JSON comparison might require types that cannot be statically analyzed";
 }

--- a/src/Tingle.Extensions.JsonPatch/JsonPatchDocumentOfT.cs
+++ b/src/Tingle.Extensions.JsonPatch/JsonPatchDocumentOfT.cs
@@ -843,9 +843,7 @@ public class JsonPatchDocument<[DynamicallyAccessedMembers(DynamicallyAccessedMe
 
     private static string GetPropertyNameFromMemberExpression(MemberExpression memberExpression)
     {
-#pragma warning disable IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
         var propertyInfo = memberExpression.Expression!.Type.GetProperty(memberExpression.Member.Name);
-#pragma warning restore IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
         var targetAttr = propertyInfo?.GetCustomAttributes(typeof(JsonPropertyNameAttribute), false)
                                       .OfType<JsonPropertyNameAttribute>()
                                       .FirstOrDefault();

--- a/src/Tingle.Extensions.Primitives/Converters/JsonStringEnumMemberConverter.cs
+++ b/src/Tingle.Extensions.Primitives/Converters/JsonStringEnumMemberConverter.cs
@@ -43,6 +43,9 @@ public class JsonStringEnumMemberConverter<[DynamicallyAccessedMembers(EnumConve
 [RequiresDynamicCode(
     "JsonStringEnumMemberConverter cannot be statically analyzed and requires runtime code generation. " +
     "Applications should use the generic JsonStringEnumMemberConverter<TEnum> instead")]
+[RequiresUnreferencedCode(
+    "JsonStringEnumMemberConverter cannot be statically analyzed and requires runtime code generation. " +
+    "Applications should use the generic JsonStringEnumMemberConverter<TEnum> instead")]
 public class JsonStringEnumMemberConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) : JsonConverterFactory
 {
     private readonly JsonNamingPolicy? namingPolicy = namingPolicy;
@@ -57,14 +60,12 @@ public class JsonStringEnumMemberConverter(JsonNamingPolicy? namingPolicy = null
     /// <inheritdoc/>
     public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
-#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
         return (JsonConverter?)Activator.CreateInstance(
                 typeof(EnumMemberConverter<>).MakeGenericType(typeToConvert),
                 BindingFlags.Instance | BindingFlags.Public,
                 binder: null,
                 args: [namingPolicy, allowIntegerValues],
                 culture: null);
-#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
     }
 }
 

--- a/tests/Tingle.Extensions.Primitives.Tests/CurrencyTests.cs
+++ b/tests/Tingle.Extensions.Primitives.Tests/CurrencyTests.cs
@@ -40,9 +40,7 @@ public class CurrencyTests
     [Fact]
     public void FromCultureWithNullCultureInfo_Throws_ArgumentNullException()
     {
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-        Assert.Throws<ArgumentNullException>(() => Currency.FromCulture(null));
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+        Assert.Throws<ArgumentNullException>(() => Currency.FromCulture(null!));
     }
 
     [Fact]

--- a/tests/Tingle.Extensions.Primitives.Tests/MoneyTests.cs
+++ b/tests/Tingle.Extensions.Primitives.Tests/MoneyTests.cs
@@ -158,9 +158,7 @@ public class MoneyTests
     [Fact]
     public void Parse_ThrowsExeception_For_Null()
     {
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-        Assert.Throws<ArgumentNullException>(() => Money.Parse(null));
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+        Assert.Throws<ArgumentNullException>(() => Money.Parse(null!));
     }
 
     [Fact]


### PR DESCRIPTION
This should allow catching errors early in the build for AoT or in the IDE. This is a non-breaking change except for AoT use cases.

Affects:
- `ContinuationTokenResult<T>`
- `JsonNodeComparer` and `JsonObjectComparer`
- `JsonStringEnumMemberConverter`